### PR TITLE
Fix predefined_goals input not accepting keyboard input

### DIFF
--- a/front/src/components/market/admin/ConfigTab.vue
+++ b/front/src/components/market/admin/ConfigTab.vue
@@ -112,12 +112,12 @@
                     <v-text-field
                       v-else-if="isArrayField(field)"
                       :label="field.title || ''"
-                      v-model="formState[field.name]"
+                      :model-value="getArrayDisplayValue(field.name)"
                       hide-details
                       density="compact"
                       variant="outlined"
                       :class="getFieldStyle(field.name)"
-                      @input="handleArrayInput(field.name, $event)"
+                      @update:model-value="(v) => { arrayDisplayStrings[field.name] = v; handleArrayInput(field.name, v) }"
                     />
                     <v-text-field
                       v-else
@@ -190,7 +190,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import axios from '@/api/axios'
 import { debounce } from 'lodash'
 import { useUIStore } from '@/store/ui'
@@ -219,6 +219,15 @@ const savingProlific = ref(false)
 const resettingState = ref(false)
 const downloading = ref(false)
 
+const arrayDisplayStrings = reactive({})
+
+const getArrayDisplayValue = (fieldName) => {
+  if (!(fieldName in arrayDisplayStrings)) {
+    const val = props.formState[fieldName]
+    arrayDisplayStrings[fieldName] = Array.isArray(val) ? val.join(', ') : String(val ?? '')
+  }
+  return arrayDisplayStrings[fieldName]
+}
 
 const traderTypes = computed(() => Object.keys(props.formState.throttle_settings || {}))
 
@@ -256,8 +265,7 @@ const getFieldType = (field) => {
 
 const isArrayField = (field) => field.type === 'array'
 
-const handleArrayInput = (fieldName, event) => {
-  const value = typeof event === 'object' && event?.target ? event.target.value : String(event ?? '')
+const handleArrayInput = (fieldName, value) => {
   if (fieldName === 'predefined_goals') {
     props.formState[fieldName] = value === '' ? [] : value.split(',').map((v) => parseInt(v.trim())).filter((n) => !isNaN(n))
   } else {


### PR DESCRIPTION
Ref #36

## Summary

- The `predefined_goals` text field in the admin dashboard only accepted paste, not typing
- Root cause: `v-model` two-way binding parsed the string into an array on every keystroke, resetting the input and breaking cursor position
- Fix: use an intermediate `arrayDisplayStrings` reactive object to hold the raw string while the user types, only parsing to array values on change

## Test plan

- [x] Verify typing `0,10,-10` in predefined_goals works character by character
- [x] Verify paste still works
- [x] Verify saved values are correct arrays