### PR TITLE
fix: show 5 order book levels in chart instead of 3

### DIFF
--- a/front/src/store/market.js
+++ b/front/src/store/market.js
@@ -70,14 +70,14 @@ export const useMarketStore = defineStore('market', {
   },
 
   actions: {
-    updateOrderBook(orderBook, gameParams) {
+    updateOrderBook(orderBook) {
       if (!orderBook) return
 
       const { bids, asks } = orderBook
-      const depthBookShown = gameParams?.depth_book_shown || 3
+      const DEPTH_BOOK_SHOWN = 5
 
-      this.orderBook.bids = bids.slice(0, depthBookShown)
-      this.orderBook.asks = asks.slice(0, depthBookShown)
+      this.orderBook.bids = bids.slice(0, DEPTH_BOOK_SHOWN)
+      this.orderBook.asks = asks.slice(0, DEPTH_BOOK_SHOWN)
       this.orderBook.midpoint = findMidpoint(this.orderBook.bids, this.orderBook.asks)
 
       this.chartData = [

--- a/front/src/store/trader.js
+++ b/front/src/store/trader.js
@@ -342,7 +342,7 @@ export const useTraderCoreStore = defineStore('traderCore', {
 
         // Update order book
         if (order_book) {
-          useMarketStore().updateOrderBook(order_book, this.gameParams)
+          useMarketStore().updateOrderBook(order_book)
         }
 
         // Update trader orders


### PR DESCRIPTION
## Summary
- Restore the order book chart to its original 5-level depth display
- Chart was slicing to `depth_book_shown || 3`, but `depth_book_shown` was removed from `TradingParameters` in c6e67d0 and never re-added — so the fallback was always hit
- Replace with a hardcoded 5 to match the original design

Ref #40

## Test plan
- [ ] Open the trading dashboard and confirm the order book chart shows 5 bid/ask levels instead of 3