### PR TITLE
fix: show 'Start Trading' on first market button in multi-participant sessions

### DIFF
--- a/front/src/components/pages/8.vue
+++ b/front/src/components/pages/8.vue
@@ -200,9 +200,6 @@ const startButtonText = computed(() => {
   if (hasClickedStart.value) return `Waiting for ${Math.max(0, waitingRoom.needed - waitingRoom.joined)} more...`
   if (isLoading.value) return 'Starting...'
   if (traderStore.isWaitingForOthers) return 'Waiting for others...'
-  if (waitingRoom.needed > 1 && waitingRoom.joined < waitingRoom.needed) {
-    return `Waiting for ${waitingRoom.needed - waitingRoom.joined} more...`
-  }
   return 'Start Trading'
 })
 


### PR DESCRIPTION
Ref #38

## Summary
- Drop the pre-click `Waiting for X more...` branch in `startButtonText` so the button reads `Start Trading` on the first market in multi-participant sessions, matching second-market behavior.
- The Participants card still shows `joined / needed` and a `Waiting for X more...` hint, so the count info isn't lost.
- Post-click behavior is unchanged: `hasClickedStart` branch still flips the button to `Waiting for X more...` after the user joins.

## Context
Alessio reported the button text on the first market said `1/2 Waiting for 1 more...`, which made it look unclickable. He noted the second market already showed `Start Trading`. This brings the first market in line.

## Test plan
- [ ] Open two browser tabs in a 2-participant treatment, log in as different users
- [ ] Both tabs land on page 8 — button reads `Start Trading` (not `Waiting for 1 more...`)
- [ ] Participants card shows `1 / 2 — Waiting for 1 more...`
- [ ] First tab clicks Start — its button flips to `Waiting for 1 more...`
- [ ] Second tab clicks Start — both navigate to /trading
- [ ] Single-participant session unchanged: button reads `Start Trading`