### PR TITLE
Speed up admin download endpoints (~280x)

### DIFF
--- a/back/api/routes/data.py
+++ b/back/api/routes/data.py
@@ -1,12 +1,13 @@
 """Data routes: /files, /files/grouped, /files/{path}, /files/download-all"""
 
-import io
+import asyncio
 import re
-import zipfile
+import tempfile
 from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse
 
 from ..auth import get_current_admin_user
 from ..shared import ROOT_DIR
@@ -114,24 +115,20 @@ async def list_files_grouped():
 @router.get("/files/download-all")
 async def download_all_logs(_=Depends(get_current_admin_user)):
     """Download all experiment data (logs, parameters, questionnaire, consent) as a single zip."""
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
-        for item in ROOT_DIR.rglob("*"):
-            if not item.is_file():
-                continue
-            # skip backup archives
-            if item.suffix in (".gz", ".tar", ".zip"):
-                continue
-            arcname = str(item.relative_to(ROOT_DIR))
-            zf.write(item, arcname)
-
-    buf.seek(0)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    return StreamingResponse(
-        buf,
-        media_type="application/zip",
-        headers={"Content-Disposition": f"attachment; filename=experiment_data_{ts}.zip"},
+    filename = f"experiment_data_{ts}.zip"
+    out = Path(tempfile.gettempdir()) / filename
+
+    proc = await asyncio.create_subprocess_exec(
+        "zip", "-r0q", str(out), ".",
+        "-x", "*.gz", "*.tar", "*.zip",
+        cwd=str(ROOT_DIR),
     )
+    rc = await proc.wait()
+    if rc != 0:
+        raise HTTPException(status_code=500, detail="Failed to build archive")
+
+    return FileResponse(out, media_type="application/zip", filename=filename)
 
 
 @router.get("/files/{file_path:path}")

--- a/back/api/routes/questionnaire.py
+++ b/back/api/routes/questionnaire.py
@@ -2,15 +2,14 @@
 
 import asyncio
 import csv
-import io
 import json
-import zipfile
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query, Response
-from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from ..auth import get_current_admin_user
@@ -149,16 +148,15 @@ async def download_questionnaire_data(current_user: dict = Depends(get_current_a
         if not json_files:
             return Response(content="No questionnaire data found", media_type="text/plain")
 
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for f in json_files:
-                zf.write(f, f.name)
-        buf.seek(0)
-
-        return StreamingResponse(
-            buf, media_type="application/zip",
-            headers={"Content-Disposition": "attachment; filename=questionnaire_data.zip"}
+        out = Path(tempfile.gettempdir()) / "questionnaire_data.zip"
+        proc = await asyncio.create_subprocess_exec(
+            "zip", "-qj", str(out), *(str(f) for f in json_files),
         )
+        rc = await proc.wait()
+        if rc != 0:
+            return Response(content="Failed to build archive", media_type="text/plain", status_code=500)
+
+        return FileResponse(out, media_type="application/zip", filename="questionnaire_data.zip")
     except Exception as e:
         return Response(content=f"Error downloading questionnaire data: {str(e)}", media_type="text/plain", status_code=500)
 

--- a/docker/Dockerfile.back
+++ b/docker/Dockerfile.back
@@ -2,6 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends zip && rm -rf /var/lib/apt/lists/*
+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock ./

--- a/front/src/components/market/admin/ConfigTab.vue
+++ b/front/src/components/market/admin/ConfigTab.vue
@@ -365,7 +365,7 @@ const downloadAll = async () => {
       responseType: 'blob',
     })
     const disposition = response.headers['content-disposition'] || ''
-    const match = disposition.match(/filename=(.+)/)
+    const match = disposition.match(/filename="?([^";]+)"?/)
     const filename = match ? match[1] : 'experiment_data.zip'
     const url = URL.createObjectURL(response.data)
     const a = document.createElement('a')


### PR DESCRIPTION
## Summary

- `/files/download-all` went from **54s → 0.19s** for a 27 MB zip (~280×)
- Replace in-Python `zipfile` + `StreamingResponse(BytesIO)` with subprocess `zip` + `FileResponse` (uses `sendfile`)
- Same anti-pattern fixed in `/admin/download_questionnaire_data`
- Frontend regex updated for RFC-6266 quoted filenames that `FileResponse` emits
- Add `zip` to backend Dockerfile

## Why it was slow

Profiling showed the zip build itself was 0.02s — the bottleneck was the response. `StreamingResponse(BytesIO, ...)` iterates a `BytesIO` line-by-line on `0x0A`. The 27 MB zip contains 273k newline bytes (log content), so FastAPI yielded **273k chunks averaging 99 bytes**, each going through the full ASGI → uvicorn → HTTP/1.1 chunked-encoding → socket-write pipeline. While that ran, the asyncio event loop was also tied up so concurrent traders' requests stalled.

The fix sidesteps the loop entirely: shell out to `zip -r0q` into a temp file (subprocess runs in 80ms), then `FileResponse` uses OS `sendfile()` for zero-copy transfer.

## Local benchmark (124 files, 27 MB)

| Step | Before | After |
|---|---|---|
| `/files/download-all` end-to-end | 54.5 s | **0.19 s** |
| ASGI chunks emitted | ~273,058 | 1 (sendfile) |

## Test plan

- [x] curl `/files/download-all`: 0.19s, valid zip, 128 files
- [x] curl `/admin/download_questionnaire_data`: 0.02s, valid zip
- [x] Response headers: `Content-Type: application/zip`, `Content-Disposition: attachment; filename="..."`, `Content-Length` set
- [x] Verify download in admin dashboard UI via Playwright (Chromium): filename `experiment_data_20260428_163309.zip` (no literal quotes), 27 MB / 128 files, zip integrity OK
- [ ] Verify production Docker image still builds with `zip` apt package added

Ref #43
