### PR TITLE
fix: reset_all() now clears all user state

### DIFF
--- a/back/api/routes/admin.py
+++ b/back/api/routes/admin.py
@@ -111,7 +111,6 @@ async def test_reset_state():
     try:
         current_settings = base_settings.copy()
         await market_handler.reset_state()
-        market_handler.session_manager.user_historical_markets.clear()
         base_settings.update(current_settings)
         accumulated_rewards.clear()
         return success(message="Test reset completed (including historical markets)")

--- a/back/core/session_manager.py
+++ b/back/core/session_manager.py
@@ -284,6 +284,9 @@ class SessionManager:
         self.user_sessions.clear()
         self.user_ready_status.clear()
         self.user_market_count.clear()
+        self.user_historical_markets.clear()
+        self.user_treatment_groups.clear()
+        self._goal_signs.clear()
         logger.info("Session manager state reset")
 
     async def remove_user_from_session(self, username: str):


### PR DESCRIPTION
## Summary
- `reset_all()` was not clearing `user_historical_markets`, `user_treatment_groups`, or `_goal_signs`
- After clicking "Reset Experiment", the platform still thought users had completed their markets and refused new sessions
- Removed redundant `user_historical_markets.clear()` from `/test/reset_state` (now covered by `reset_all()`)

Ref #50

## Test plan
- [x] Before fix: `user_historical_markets` persists after `reset_all()` — bug confirmed
- [x] After fix: all state cleared — verified