### PR TITLE
fix: Continue to Next Market button disabled by stale questionnaire data

### DIFF
--- a/back/api/routes/admin.py
+++ b/back/api/routes/admin.py
@@ -13,6 +13,7 @@ from core.treatment_manager import treatment_manager
 from ..auth import get_current_user, get_current_admin_user
 from ..shared import base_settings, market_handler, accumulated_rewards
 from utils.api_responses import success, not_found
+from .questionnaire import clear_questionnaire_data
 
 router = APIRouter()
 
@@ -100,6 +101,7 @@ async def reset_state(current_user: dict = Depends(get_current_admin_user)):
         await market_handler.reset_state()
         base_settings.update(current_settings)
         accumulated_rewards.clear()
+        clear_questionnaire_data()
         return success(message="Application state reset successfully")
     except Exception:
         raise HTTPException(status_code=500, detail="Error resetting application state")
@@ -113,6 +115,7 @@ async def test_reset_state():
         await market_handler.reset_state()
         base_settings.update(current_settings)
         accumulated_rewards.clear()
+        clear_questionnaire_data()
         return success(message="Test reset completed (including historical markets)")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Reset failed: {str(e)}")

--- a/back/api/routes/questionnaire.py
+++ b/back/api/routes/questionnaire.py
@@ -52,6 +52,18 @@ def _get_questionnaire_dir():
     return d
 
 
+def clear_questionnaire_data():
+    """Archive questionnaire JSON files into a timestamped subdirectory. Called on experiment reset."""
+    d = _get_questionnaire_dir()
+    json_files = list(d.glob("*.json"))
+    if json_files:
+        archive_dir = d / "archive" / datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        for f in json_files:
+            f.rename(archive_dir / f.name)
+    _trader_locks.clear()
+
+
 def _get_trader_json_path(trader_id: str) -> Path:
     return _get_questionnaire_dir() / f"{trader_id}.json"
 

--- a/front/src/components/market/MarketSummary.vue
+++ b/front/src/components/market/MarketSummary.vue
@@ -47,9 +47,9 @@
             </div>
           </div>
 
-          <!-- Per-market questions (shown after every market) -->
+          <!-- Per-market questions (shown after every market, hidden only on last market after final questionnaire) -->
           <div
-            v-if="traderSpecificMetrics && !questionnaireCompleted"
+            v-if="traderSpecificMetrics && !(isLastMarket && questionnaireCompleted)"
             class="questionnaire-section"
           >
             <div class="section-label">Answer the following question to continue:</div>


### PR DESCRIPTION
## Summary
- **Root cause**: After experiment reset, stale `postmarket_responses` in questionnaire JSON files caused `questionnaireCompleted=true`, hiding the per-market questionnaire and leaving the "Continue to Next Market" button permanently disabled
- **Frontend**: Changed per-market question `v-if` from `!questionnaireCompleted` to `!(isLastMarket && questionnaireCompleted)` so it always shows on non-last markets
- **Backend**: On reset, questionnaire files are archived to `questionnaire/archive/{timestamp}/` instead of deleted — preserves history while starting fresh

## Test plan
- [x] Reproduced bug: created stale questionnaire file, played one market, confirmed button was disabled and questionnaire missing
- [x] Applied fix: reloaded summary page, confirmed questionnaire appeared and button enabled after answering
- [x] Verified archive: reset state, confirmed files moved to `questionnaire/archive/` subdirectory (not deleted)

Ref #52