### PR TITLE
feat: show task in Market Info panel, remove trading tips

### DIFF
--- a/front/src/components/TradingDashboard.vue
+++ b/front/src/components/TradingDashboard.vue
@@ -78,7 +78,7 @@
               <div class="panel mb-4">
                 <div class="panel-title">Market Info</div>
                 <div class="panel-body">
-                  <MarketMessages :isGoalAchieved="isGoalAchieved" :goalType="goalType" />
+                  <MarketMessages :isGoalAchieved="isGoalAchieved" :goalType="goalType" :goal="goal" />
                 </div>
               </div>
             </v-col>

--- a/front/src/components/TradingDashboard.vue
+++ b/front/src/components/TradingDashboard.vue
@@ -17,7 +17,6 @@
         <div class="header-inner">
           <h1 class="dashboard-title">LOBX</h1>
           <div class="dashboard-stats">
-            <span class="role-label">{{ roleDisplay.text }}</span>
             <div class="stats-row">
               <div class="stat-item">
                 <span class="stat-label">PnL</span>
@@ -238,18 +237,6 @@ watch(isGoalAchieved, (newValue) => {
 const marketTimeRemaining = ref(null)
 const marketTimeoutInterval = ref(null)
 
-const roleDisplay = computed(() => {
-  if (!goalLoaded.value) {
-    return { text: 'Loading...' }
-  }
-  if (!hasGoal.value) {
-    return { text: 'SPECULATOR' }
-  }
-  if (goal.value > 0) {
-    return { text: 'INFORMED (BUY)' }
-  }
-  return { text: 'INFORMED (SELL)' }
-})
 
 watch(isTradingStarted, (newValue) => {
   if (newValue && marketTimeoutInterval.value) {
@@ -356,15 +343,6 @@ onMounted(() => {
   flex-wrap: wrap;
   align-items: center;
   gap: 10px;
-}
-
-.role-label {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  font-weight: var(--font-bold);
-  color: var(--color-text-secondary);
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
 }
 
 .stats-row {

--- a/front/src/components/TradingPreview.vue
+++ b/front/src/components/TradingPreview.vue
@@ -15,7 +15,6 @@
       <div class="mock-header" :class="{ highlighted: highlight === 'header', dimmed: highlight !== 'header' && highlight !== 'all' }">
         <span class="mock-title">LOBX</span>
         <div class="mock-stats">
-          <span>SPECULATOR</span>
           <span>PnL: -5</span>
           <span>Shares: 10 +0</span>
           <span>Cash: 1195</span>
@@ -91,12 +90,7 @@
                 <div class="mock-info-value">1</div>
               </div>
             </div>
-            <div class="mock-tip">
-              <ul>
-                <li>Market up → <strong class="bid-color">Buy now</strong>, sell later</li>
-                <li>Market down → <strong class="ask-color">Sell now</strong>, buy later</li>
-              </ul>
-            </div>
+            <div class="mock-task">Your Task is Maximise Profits</div>
           </div>
         </div>
 

--- a/front/src/components/trading/MarketMessages.vue
+++ b/front/src/components/trading/MarketMessages.vue
@@ -20,10 +20,17 @@
       </div>
     </div>
 
+    <div class="task-display" :class="taskClass">
+      {{ taskText }}
+    </div>
+
+    <!-- Trading tips removed per issue #56 to avoid suggesting strategy -->
+    <!--
     <div class="trading-tip">
       <div class="tip-row">If you believe the market will go up: <strong class="bid-color">Buy now</strong> and sell later.</div>
       <div class="tip-row">If you believe the market will go down: <strong class="ask-color">Sell now</strong> and buy later.</div>
     </div>
+    -->
   </div>
 </template>
 
@@ -32,7 +39,28 @@ import { ref, onMounted, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMarketStore } from '@/store/market'
 
+const props = defineProps({
+  isGoalAchieved: { type: Boolean, default: false },
+  goalType: { type: String, default: 'free' },
+  goal: { type: Number, default: null },
+})
+
 const { extraParams } = storeToRefs(useMarketStore())
+
+const taskText = computed(() => {
+  if (!props.goal || props.goal === 0) {
+    return 'Your Task is Maximise Profits'
+  }
+  if (props.goal > 0) {
+    return `Your Task is To Buy ${props.goal} Shares`
+  }
+  return `Your Task is To Sell ${Math.abs(props.goal)} Shares`
+})
+
+const taskClass = computed(() => {
+  if (!props.goal || props.goal === 0) return 'task-speculator'
+  return props.goal > 0 ? 'task-buy' : 'task-sell'
+})
 
 const filteredParams = computed(() => {
   return extraParams.value.filter((p) => p.var_name !== 'imbalance')
@@ -136,6 +164,28 @@ onMounted(() => {
 }
 
 .val-red {
+  color: var(--color-ask);
+}
+
+.task-display {
+  margin-top: 12px;
+  padding: 14px 12px;
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  text-align: center;
+  letter-spacing: var(--tracking-wide);
+}
+
+.task-speculator {
+  color: var(--color-text-primary);
+}
+
+.task-buy {
+  color: var(--color-bid);
+}
+
+.task-sell {
   color: var(--color-ask);
 }
 


### PR DESCRIPTION
## Summary
- Task description now displayed prominently in the Market Info panel with colored bold text
  - Speculator: "Your Task is Maximise Profits"
  - Informed (buy): "Your Task is To Buy X Shares" (green)
  - Informed (sell): "Your Task is To Sell X Shares" (red)
- Commented out trading tips ("Market up → Buy now, sell later") to avoid suggesting strategy

Ref #56

## Verification
Tested locally with Playwright — all 3 task types display correctly in Market Info panel:
- `goal=10` → "Your Task is To Buy 10 Shares"
- `goal=0` → "Your Task is Maximise Profits"
- `goal=-8` → "Your Task is To Sell 8 Shares"