### PR TITLE
ci: harden Durham deployment secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,18 @@
-# .dockerignore
+# Keep local secrets and generated runtime state out of Docker build contexts
+.git
+.env
+.env.*
+*.secrets
+.secrets/
+*service-account*.json
 
-# Include everything
-!**
+back/config/auth/
+back/logs/
+front/.env
+front/.env.*
+front/.firebase/
+
+__pycache__/
+*.pyc
+.pytest_cache/
+node_modules/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Firebase web config
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+FIREBASE_MEASUREMENT_ID=
+
+# Backend/runtime secrets
+OPENROUTER_API_KEY=
+TURNSTILE_SECRET_KEY=
+TURNSTILE_SITE_KEY=
+
+# ngrok tunnel used by production backend exposure
+NGROK_AUTHTOKEN=
+NGROK_DOMAIN=dthinkr.ngrok.app
+
+# Optional local frontend deploy path
+FIREBASE_TOKEN=

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Create secret files
-      run: |
-        mkdir -p ./back/config/auth
-        echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > ./back/config/auth/firebase-service-account.json
-
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
@@ -28,7 +23,9 @@ jobs:
         context: ./back
         file: ./docker/Dockerfile.back
         push: true
-        tags: venvoo/trading_platform:back
+        tags: |
+          venvoo/trading_platform:back
+          venvoo/trading_platform:back-${{ github.sha }}
 
   deploy-backend:
     needs: build-backend
@@ -42,17 +39,38 @@ jobs:
         key: ${{ secrets.SERVER_SSH_KEY }}
         passphrase: ${{ secrets.SERVER_SSH_PASSPHRASE }}
         script: |
+          set -e
           cd /root/trading_platform
-          # Ensure required env vars
-          for VAR_LINE in \
-            "TURNSTILE_SECRET_KEY=${{ secrets.TURNSTILE_SECRET_KEY }}" \
-            "ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}" \
-          ; do
-            VAR_NAME="${VAR_LINE%%=*}"
-            grep -q "^${VAR_NAME}=" .env 2>/dev/null \
-              && sed -i "s|^${VAR_NAME}=.*|${VAR_LINE}|" .env \
-              || echo "${VAR_LINE}" >> .env
-          done
+          touch .env
+
+          upsert_env_var() {
+            name="$1"
+            value="$2"
+            if [ -z "$value" ]; then
+              echo "Skipping $name because value is empty"
+              return
+            fi
+            grep -q "^${name}=" .env 2>/dev/null \
+              && sed -i "s|^${name}=.*|${name}=${value}|" .env \
+              || echo "${name}=${value}" >> .env
+          }
+
+          upsert_env_var TURNSTILE_SECRET_KEY '${{ secrets.TURNSTILE_SECRET_KEY }}'
+          upsert_env_var ADMIN_PASSWORD '${{ secrets.ADMIN_PASSWORD }}'
+          upsert_env_var NGROK_AUTHTOKEN '${{ secrets.NGROK_AUTHTOKEN }}'
+
+          if ! grep -q '^NGROK_AUTHTOKEN=' .env 2>/dev/null && [ -n '${{ secrets.NGROK_YML }}' ]; then
+            cat > /tmp/lobx-ngrok.yml <<'EOF'
+          ${{ secrets.NGROK_YML }}
+          EOF
+            legacy_ngrok_token="$(awk -F': *' '/^authtoken:/ {print $2; exit}' /tmp/lobx-ngrok.yml)"
+            rm -f /tmp/lobx-ngrok.yml
+            upsert_env_var NGROK_AUTHTOKEN "$legacy_ngrok_token"
+          fi
+
+          git fetch origin main
+          git reset --hard origin/main
+          chmod +x ./deploy.sh
           ./deploy.sh
 
   deploy-frontend:
@@ -85,4 +103,3 @@ jobs:
         projectId: london-trader
         channelId: live
         entryPoint: ./front
-  

--- a/back/.dockerignore
+++ b/back/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+config/auth/
+logs/
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/root/trading_platform}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.server.yml}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
+
+cd "$APP_DIR"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "Missing $COMPOSE_FILE in $APP_DIR"
+  exit 1
+fi
+
+if [ ! -f ".env" ]; then
+  echo "Missing .env in $APP_DIR"
+  exit 1
+fi
+
+if [ ! -f "back/config/auth/firebase-service-account.json" ]; then
+  echo "Missing back/config/auth/firebase-service-account.json"
+  exit 1
+fi
+
+if ! grep -q '^NGROK_AUTHTOKEN=' .env && [ -z "${NGROK_AUTHTOKEN:-}" ]; then
+  echo "Missing NGROK_AUTHTOKEN in .env or environment"
+  exit 1
+fi
+
+echo "Updating repository from origin/${DEPLOY_BRANCH}..."
+git fetch origin "$DEPLOY_BRANCH"
+git reset --hard "origin/${DEPLOY_BRANCH}"
+
+echo "Pulling backend image..."
+docker compose -f "$COMPOSE_FILE" pull back
+
+echo "Starting services..."
+docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans
+
+docker compose -f "$COMPOSE_FILE" ps

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -9,7 +9,7 @@ services:
       - ./back/config:/app/config:Z
       - ./back/logs:/app/logs:Z
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - PORT=8000
       - ROOT_PATH=
@@ -22,7 +22,7 @@ services:
       - FIREBASE_MEASUREMENT_ID=${FIREBASE_MEASUREMENT_ID}
       - GOOGLE_APPLICATION_CREDENTIALS=/app/config/auth/firebase-service-account.json
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-    command: sh -c "uv sync && uv run uvicorn api.endpoints:app --host 0.0.0.0 --port 8000 --root-path $${ROOT_PATH:-/api}"
+    command: sh -c "uv run uvicorn api.endpoints:app --host 0.0.0.0 --port 8000 --root-path $${ROOT_PATH:-/api}"
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -39,9 +39,9 @@ services:
       - "http"
       - "localhost:8000"
       - "--hostname"
-      - "dthinkr.ngrok.app"
+      - "${NGROK_DOMAIN:-dthinkr.ngrok.app}"
       - "--authtoken"
-      - "2j4K90jU5KvNPr1zFNnOes5QnU9_334pieyQKiRBBb6WFpsDp"
+      - "${NGROK_AUTHTOKEN:?NGROK_AUTHTOKEN_required}"
     network_mode: host
     depends_on:
       - back

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,9 +91,9 @@ services:
       - "http"
       - "localhost:8000"
       - "--hostname"
-      - "dthinkr.ngrok.app"
+      - "${NGROK_DOMAIN:-dthinkr.ngrok.app}"
       - "--authtoken"
-      - "2j4K90jU5KvNPr1zFNnOes5QnU9_334pieyQKiRBBb6WFpsDp"
+      - "${NGROK_AUTHTOKEN:?NGROK_AUTHTOKEN_required}"
     network_mode: host  # This gives direct localhost access like your working setup
     depends_on:
       - back
@@ -113,4 +113,3 @@ volumes: {}
 networks:
   app-network:
     driver: bridge
-

--- a/run.sh
+++ b/run.sh
@@ -98,10 +98,11 @@ elif [ "$MODE" = "batch" ]; then
 
 elif [ "$MODE" = "deploy" ]; then
     set -e
-    echo "🚀 deploying from refactoring-v2..."
+    DEPLOY_BRANCH=${DEPLOY_BRANCH:-main}
+    echo "🚀 deploying from origin/${DEPLOY_BRANCH}..."
     
-    git fetch origin
-    git reset --hard origin/refactoring-v2
+    git fetch origin "$DEPLOY_BRANCH"
+    git reset --hard "origin/${DEPLOY_BRANCH}"
     
     docker compose down
     docker compose pull || echo "⚠️  no remote images, using local build"


### PR DESCRIPTION
Ref #60

## Summary

- Remove secret file creation from the backend Docker build path so Firebase service account JSON is not copied into the image.
- Add Docker ignore rules for env files, service account JSON, logs, caches, and local dependency folders.
- Move the ngrok authtoken out of compose files and into runtime environment configuration.
- Add a repo-visible Durham `deploy.sh` and make the GitHub Actions SSH deploy reset to `origin/main` before running it.
- Preserve existing `ADMIN_PASSWORD` and `TURNSTILE_SECRET_KEY` server env syncing, and add `NGROK_AUTHTOKEN` sync with a legacy `NGROK_YML` fallback while the token is being rotated.
- Bind the production backend port to `127.0.0.1:8000` so public access goes through ngrok instead of a bare exposed port.
- Add `.env.example` for handover.

## Tests

- `git diff --check`
- `bash -n deploy.sh && bash -n run.sh`
- YAML parse of `.github/workflows/docker-build-push.yml`
- `NGROK_AUTHTOKEN=dummy docker compose -f docker-compose.server.yml config --quiet`
- `NGROK_AUTHTOKEN=dummy docker compose -f docker-compose.yml config --quiet`
- searched touched deployment files for the previously exposed ngrok token prefix: no matches
- Firebase frontend responds with HTTP 200 at `https://london-trader.web.app/`

## Notes

- Docker daemon is not available on this local machine, so I could not do a local image build.
- Direct SSH to `p-trade-01.econ.dur.ac.uk` from this machine is currently denied by server key policy, so I could not inspect Durham containers directly.
- `https://dthinkr.ngrok.app/` timed out from this network during verification. That is not caused by this unmerged branch, but it should be checked on the Durham server.
- Wiki documentation is here: https://github.com/lobx-platform/lobx/wiki/Deployment-CICD