### PR TITLE
ci: login to DockerHub before Durham deploy

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -70,6 +70,9 @@ jobs:
 
           git fetch origin main
           git reset --hard origin/main
+          echo '${{ secrets.DOCKERHUB_TOKEN }}' | docker login docker.io \
+            --username '${{ secrets.DOCKERHUB_USERNAME }}' \
+            --password-stdin
           chmod +x ./deploy.sh
           ./deploy.sh
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ git fetch origin "$DEPLOY_BRANCH"
 git reset --hard "origin/${DEPLOY_BRANCH}"
 
 echo "Pulling backend image..."
-docker compose -f "$COMPOSE_FILE" pull back
+docker compose -f "$COMPOSE_FILE" pull back || echo "Backend image pull failed; continuing with any existing local image"
 
 echo "Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans


### PR DESCRIPTION
Ref #60

## Summary

- Log in to DockerHub on the Durham server before running `deploy.sh`, using the existing GitHub DockerHub secrets.
- Make `docker compose pull back` non-fatal in `deploy.sh`, so a DockerHub pull problem does not stop the script before trying an existing local image.

## Why

The #61 post-merge deploy reached Durham successfully, but failed at `docker compose pull back` with DockerHub access denied before any container restart. This follow-up addresses that specific deployment failure.

## Tests

- `git diff --check`
- `bash -n deploy.sh`
- YAML parse of `.github/workflows/docker-build-push.yml`
- `NGROK_AUTHTOKEN=dummy docker compose -f docker-compose.server.yml config --quiet`