### PR TITLE
ci: avoid Durham default network conflict

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -24,6 +24,8 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
     command: sh -c "uv run uvicorn api.endpoints:app --host 0.0.0.0 --port 8000 --root-path $${ROOT_PATH:-/api}"
     restart: unless-stopped
+    networks:
+      - server-network
     logging:
       driver: "json-file"
       options:
@@ -50,3 +52,8 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+networks:
+  server-network:
+    name: trading_platform_server
+    driver: bridge


### PR DESCRIPTION
Ref #60

## Summary

- Add an explicit `server-network` named `trading_platform_server` to `docker-compose.server.yml`.
- Attach the backend service to that explicit network so Durham's old `trading_platform_default` Podman/compose network does not block `docker compose up`.

## Why

The #62 post-merge deploy reached `docker compose up`, but Durham failed with:

`network trading_platform_default was found but has incorrect label com.docker.compose.network set to ""`

Using an explicit network avoids the stale/default network conflict.

## Tests

- `git diff --check`
- `NGROK_AUTHTOKEN=dummy docker compose -f docker-compose.server.yml config --quiet`