### PR TITLE
ci: clear old Durham backend container before deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,6 +34,16 @@ git reset --hard "origin/${DEPLOY_BRANCH}"
 echo "Pulling backend image..."
 docker compose -f "$COMPOSE_FILE" pull back || echo "Backend image pull failed; continuing with any existing local image"
 
+echo "Stopping existing compose services..."
+docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
+
+echo "Freeing containers that still publish port 8000..."
+PORT_8000_CONTAINERS="$(docker ps --format '{{.ID}} {{.Ports}}' | awk '/127\.0\.0\.1:8000|0\.0\.0\.0:8000|:8000->/ {print $1}')"
+if [ -n "$PORT_8000_CONTAINERS" ]; then
+  docker stop $PORT_8000_CONTAINERS
+  docker rm $PORT_8000_CONTAINERS
+fi
+
 echo "Starting services..."
 docker compose -f "$COMPOSE_FILE" up -d --build --remove-orphans
 


### PR DESCRIPTION
Ref #60

## Summary

- Stop existing compose services before starting the Durham stack.
- Remove any old container still publishing port 8000 before `docker compose up`.

## Why

The #63 post-merge deploy reached container startup, but failed because `127.0.0.1:8000` was already in use by an old backend container/process. This makes the deploy script explicitly clear that old container before starting the new backend.

## Tests

- `git diff --check`
- `bash -n deploy.sh`