### PR TITLE
ci: remove stale Durham platform containers

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -37,11 +37,21 @@ docker compose -f "$COMPOSE_FILE" pull back || echo "Backend image pull failed; 
 echo "Stopping existing compose services..."
 docker compose -f "$COMPOSE_FILE" down --remove-orphans || true
 
+echo "Removing stale trading_platform containers..."
+OLD_NGROK_CONTAINERS="$(docker ps -a --format '{{.ID}} {{.Names}}' | awk '/ngrok/ {print $1}')"
+if [ -n "$OLD_NGROK_CONTAINERS" ]; then
+  docker rm -f $OLD_NGROK_CONTAINERS || true
+fi
+
+OLD_PLATFORM_CONTAINERS="$(docker ps -a --format '{{.ID}} {{.Names}}' | awk '/trading_platform/ {print $1}')"
+if [ -n "$OLD_PLATFORM_CONTAINERS" ]; then
+  docker rm -f $OLD_PLATFORM_CONTAINERS || true
+fi
+
 echo "Freeing containers that still publish port 8000..."
 PORT_8000_CONTAINERS="$(docker ps --format '{{.ID}} {{.Ports}}' | awk '/127\.0\.0\.1:8000|0\.0\.0\.0:8000|:8000->/ {print $1}')"
 if [ -n "$PORT_8000_CONTAINERS" ]; then
-  docker stop $PORT_8000_CONTAINERS
-  docker rm $PORT_8000_CONTAINERS
+  docker rm -f $PORT_8000_CONTAINERS || true
 fi
 
 echo "Starting services..."


### PR DESCRIPTION
Ref #60

## Summary

- Force-remove stale Durham `ngrok` / `trading_platform` containers before starting the new compose stack.
- Make the port-8000 cleanup non-fatal after forced removal.

## Why

The #64 deploy removed the current compose containers, but then failed removing an old underscore-style backend container because it had a dependent stale container. Removing stale platform/ngrok containers first should clear that dependency chain before startup.

## Tests

- `git diff --check`
- `bash -n deploy.sh`