### PR TITLE
ci: use empty root path for Durham backend

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -22,7 +22,7 @@ services:
       - FIREBASE_MEASUREMENT_ID=${FIREBASE_MEASUREMENT_ID}
       - GOOGLE_APPLICATION_CREDENTIALS=/app/config/auth/firebase-service-account.json
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-    command: sh -c "uv run uvicorn api.endpoints:app --host 0.0.0.0 --port 8000 --root-path $${ROOT_PATH:-/api}"
+    command: sh -c 'uv run uvicorn api.endpoints:app --host 0.0.0.0 --port 8000 --root-path "$${ROOT_PATH:-}"'
     restart: unless-stopped
     networks:
       - server-network


### PR DESCRIPTION
Ref #60

## Summary

- Change the Durham backend uvicorn command to use an empty root path when `ROOT_PATH=` is configured.

## Why

Playwright found that `https://dthinkr.ngrok.app/docs` loaded Swagger UI but failed to fetch `/api/openapi.json` with 404. The actual OpenAPI endpoint is at `/openapi.json`; the incorrect `/api` prefix came from shell expansion defaulting empty `ROOT_PATH` to `/api`.

## Tests

- `git diff --check`
- `NGROK_AUTHTOKEN=dummy docker compose -f docker-compose.server.yml config --quiet`