### PR TITLE
Make Real Sessions log-analysis scripts runnable by anyone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,9 @@ Thumbs.db
 # ====================
 REVIEW.md
 papers/
-analysis/
+# analysis/ is local-only EXCEPT the committed real-sessions log-analysis pipeline
+/analysis/*
+!/analysis/real-sessions/
 designs/
 docs/
 agentic-paper/

--- a/analysis/real-sessions/.gitignore
+++ b/analysis/real-sessions/.gitignore
@@ -1,0 +1,9 @@
+# Local session data + generated outputs — NEVER commit (human-subjects data).
+_local_data/
+*.log
+all_*.csv
+filtered_*.csv
+payment_*.csv
+*_markets.csv
+*_OB.csv
+__pycache__/

--- a/analysis/real-sessions/analysis.py
+++ b/analysis/real-sessions/analysis.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pandas as pd
+import os
+from datetime import datetime
+import random
+
+def remove_first_market(df_i):
+    df_i= df_i.loc[df_i['Id'] != 0].reset_index(drop=True)
+    return df_i
+
+from settings import BASE_DIR, FOLDER, DATE, DAYSTATS_SUBFOLDER
+
+pathname = BASE_DIR
+folder = FOLDER
+date_of_session = DATE
+file = 'all_' + date_of_session + '.csv'
+
+filename1 = pathname + '/' + folder + '/' + DAYSTATS_SUBFOLDER + '/' + file
+#filename2 = pathname + '/' + folder + '/' +  'Prolific_ID_Exclude.csv'
+
+
+df = pd.read_csv(filename1, header=0)
+df['Session'] = df['Market'].str.rsplit('_', n=1).str[0]
+df['Id'] = df['Market'].str.split('_').str[-1].astype(int)
+
+#df_to_exclude = pd.read_csv(filename2, header=0)
+
+
+#df_filtered = df[~df['Trader'].isin(df_to_exclude['Trader'])]
+
+df_filtered = df
+# pandas-version-stable equivalent of groupby('Session').apply(remove_first_market):
+# Id is the per-session market index, so dropping Id==0 drops each session's first market.
+df_filtered_final = df_filtered[df_filtered['Id'] != 0].sort_values(by=['Session', 'Id']).reset_index(drop=True)
+
+save_file_path = pathname + '/' + folder + '/' + DAYSTATS_SUBFOLDER + '/' + f'filtered_{date_of_session}.csv'
+
+NON_HUMAN_LABEL = 'no_human'
+
+def replace_nohuman(group):
+    # extract human names (LAB_*)
+    humans = group.loc[group['Trader'] != NON_HUMAN_LABEL, 'Trader'].unique()
+
+    # only act if at least one human exists
+    if len(humans) > 0:
+        replacement = humans[0]  # or random.choice(humans)
+
+        group.loc[group['Trader'] == NON_HUMAN_LABEL, 'Trader'] = replacement
+
+    return group
+
+# pandas-version-stable equivalent of groupby('Session').apply(replace_nohuman):
+# within each session, relabel 'no_human' rows with that session's (first) human trader.
+_session_human = (df_filtered_final[df_filtered_final['Trader'] != NON_HUMAN_LABEL]
+                  .groupby('Session')['Trader'].first())
+_nohuman_mask = df_filtered_final['Trader'] == NON_HUMAN_LABEL
+df_filtered_final.loc[_nohuman_mask, 'Trader'] = (
+    df_filtered_final.loc[_nohuman_mask, 'Session'].map(_session_human).fillna(NON_HUMAN_LABEL)
+)
+
+
+df_filtered_final.to_csv(save_file_path, index=False)
+
+df_filtered_final_payment = df_filtered_final.loc[df_filtered_final.Id == 5].groupby('Session').first().reset_index()[['Session', 'Trader' ,'PnL_Original']]
+df_filtered_final_payment['Euro'] = (df_filtered_final_payment['PnL_Original'] / 2).clip(lower=0, upper=10)
+save_file_path = pathname + '/' + folder + '/' + DAYSTATS_SUBFOLDER + '/' + f'payment_{date_of_session}.csv'
+df_filtered_final_payment.to_csv(save_file_path, index=False)

--- a/analysis/real-sessions/functions.py
+++ b/analysis/real-sessions/functions.py
@@ -1,0 +1,548 @@
+import pandas as pd
+import numpy as np
+import random
+
+def logfile_to_message(logfile_name):
+    log_file_path = logfile_name
+    timestamp_save = []
+    price_save = []
+    amount_save = []
+    direction_save = []
+    trader_save = []
+    type_save = []
+    trader_recorded = []
+
+
+    with open(log_file_path, 'r') as log_file:
+        for line in log_file:
+            timestamp_str, level, msg = line.split(" - ", 2)
+            msg_type, msg_content = msg.split(": ", 1)
+
+            if msg_type == 'ADD_ORDER':
+
+                amount_key = "'amount': "
+                start_index = msg_content.index(amount_key) + len(amount_key)
+                end_index = msg_content.index(',', start_index)
+                amount_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                amount = float(amount_str)
+
+                price_key = "'price': "
+                start_index = msg_content.index(price_key) + len(price_key)
+                end_index = msg_content.index(',', start_index)
+                price_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                price = float(price_str)
+
+                direction_key = "<OrderType."
+                start_index = msg_content.index(direction_key) + len(direction_key)
+                end_index = msg_content.index(':', start_index)
+                direction_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                direction = direction_str
+
+                trader_key = "'trader_id': "
+                start_index = msg_content.index(trader_key) + len(trader_key)
+                end_index = msg_content.index(',', start_index)
+                trader_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                trader_type = (trader_str)
+
+                price_save.append(price)
+                amount_save.append(amount)
+                direction_save.append(direction)
+                trader_save.append(trader_type)
+                timestamp_save.append(timestamp_str)
+                type_save.append(msg_type)
+
+            if msg_type == 'CANCEL_ORDER':
+
+                amount_key = "'amount': "
+                start_index = msg_content.index(amount_key) + len(amount_key)
+                end_index = msg_content.index(',', start_index)
+                amount_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                amount = float(amount_str)
+
+                price_key = "'price': "
+                start_index = msg_content.index(price_key) + len(price_key)
+                end_index = msg_content.index(',', start_index)
+                price_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                price = float(price_str)
+
+
+                direction_key = "<OrderType."
+                start_index = msg_content.index(direction_key) + len(direction_key)
+                end_index = msg_content.index(':', start_index)
+                direction_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                direction = direction_str
+
+                trader_key = "'trader_id': "
+                start_index = msg_content.index(trader_key) + len(trader_key)
+                end_index = msg_content.index(',', start_index)
+                trader_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                trader_type = (trader_str)
+
+                price_save.append(price)
+                amount_save.append(amount)
+                direction_save.append(direction)
+                trader_save.append(trader_type)
+                timestamp_save.append(timestamp_str)
+                type_save.append(msg_type)
+
+            if msg_type == 'RECORD_KEEPING_ORDER':
+                trader_key = "'trader_id': "
+                start_index = msg_content.index(trader_key) + len(trader_key)
+                end_index = msg_content.index(',', start_index)
+                trader_str = msg_content[start_index:end_index].strip()  # Extract and strip whitespace
+                trader_type_recorded = (trader_str)
+                trader_recorded.append(trader_type_recorded)
+
+
+
+
+    df = pd.DataFrame({'Timestamp': timestamp_save,
+                  'Price': price_save,
+                  'Amount': amount_save,
+                  'Direction': direction_save,
+                  'Type' : type_save,
+                  'Trader': trader_save})
+
+    df['Timestamp'] = pd.to_datetime(df['Timestamp'].str.replace(',', '.'), format='%Y-%m-%d %H:%M:%S.%f')
+
+
+    return df, trader_recorded
+
+
+
+
+def get_best_ask_order(orders):
+    best_ask_order = min(orders['ASKS'], key=lambda x: (x['Price'], x['Timestamp']))
+    return best_ask_order
+
+
+def get_best_bid_order(orders):
+    best_bid_price = max(order['Price'] for order in orders['BIDS'])
+
+    orders_to_check = []
+    for order in orders['BIDS']:
+        if order['Price'] == best_bid_price:
+            orders_to_check.append(order)
+
+    best_bid_order = min(orders_to_check, key=lambda x:  x['Timestamp'])
+    return best_bid_order
+
+
+def get_random_order(orders,trader):
+    random_orders = []
+    for order in orders:
+        if order['Trader'] == trader:
+            random_orders.append(order)
+
+    if random_orders:
+        return_order = random.choice(random_orders)
+    else:
+        return_order = {}
+
+    return return_order
+
+def get_order_to_cancel(orders,trader,price):
+    orders_trader = [order for order in orders if order['Trader'] ==trader]
+    orders_at_price = [order for order in orders_trader if order['Price'] ==price]
+
+    if orders_at_price:
+        order_to_cancel = max(orders_at_price, key=lambda order: order['Timestamp'])
+        return order_to_cancel
+    else:
+        return None
+
+
+
+def order_book_contruction(logfile_name):
+    message_df, all_metrics = process_logfile(logfile_name)
+    return all_metrics
+
+def process_logfile(logfile_name):
+    message_df, trader_type_recorded  = logfile_to_message(logfile_name)
+    all_traders = list(np.unique(message_df.Trader))
+
+    if trader_type_recorded and trader_type_recorded not in all_traders:
+        all_traders = all_traders + [trader_type_recorded]
+
+    trades_by_human = {}
+    trades_by_informed_machine = {}
+
+
+    for trader in all_traders:
+        if 'HUMAN' in trader:
+            trades_by_human[trader] = []
+        if 'INFORMED' in trader:
+            trades_by_informed_machine[trader] = []
+
+    orders = {'BIDS': [],'ASKS': []}
+    total_trades = 0
+    total_cancellations = 0
+    all_midprices = []
+    all_best_bid_prices = []
+    all_best_ask_prices = []
+
+    start_time = message_df['Timestamp'].iloc[0]
+    message_df['New_Timestamp'] = (message_df['Timestamp'] - start_time).dt.total_seconds()
+    order_book = pd.DataFrame()
+
+    for index, row in message_df.iterrows():
+        timestamp = row['Timestamp']
+        price = row['Price']
+        amount = row['Amount']
+        direction = row['Direction']
+        order_type = row['Type']
+        trader = row['Trader']
+
+        new_order = {'Timestamp':timestamp,
+                     'Price': price,
+                     'Amount':amount,
+                     'Direction': direction,
+                     'Trader':trader}
+
+        best_bid_price = max((order['Price'] for order in orders['BIDS']), default=None)
+        best_ask_price = min((order['Price'] for order in orders['ASKS']), default=None)
+
+
+        if 'INFORMED' in trader:
+            if direction == 'BID':
+                informed_direction = 'Buy'
+            else:
+                informed_direction = 'Sell'
+
+        if order_type =='ADD_ORDER':
+            if direction == 'BID':
+                if best_ask_price is None:
+                    orders['BIDS'].append(new_order)
+                elif price < best_ask_price:
+                    orders['BIDS'].append(new_order)
+                else:
+                    order_to_remove = get_best_ask_order(orders)
+                    orders['ASKS'].remove(order_to_remove)
+                    total_trades +=1
+                    if trader in trades_by_human:
+                        trades_by_human[trader].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Buy'})
+                    if order_to_remove['Trader'] in trades_by_human:
+                        name_to_use = order_to_remove['Trader']
+                        trades_by_human[name_to_use].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Sell'})
+                    if trader in trades_by_informed_machine:
+                        trades_by_informed_machine[trader].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Buy'})
+                    if order_to_remove['Trader'] in trades_by_informed_machine:
+                        name_to_use = order_to_remove['Trader']
+                        trades_by_informed_machine[name_to_use].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Sell'})
+
+            else:
+                if best_bid_price is None:
+                    orders['ASKS'].append(new_order)
+                elif price > best_bid_price:
+                    orders['ASKS'].append(new_order)
+                else:
+                    order_to_remove = get_best_bid_order(orders)
+                    orders['BIDS'].remove(order_to_remove)
+                    total_trades +=1
+                    if trader in trades_by_human:
+                        trades_by_human[trader].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Sell'})
+                    if order_to_remove['Trader'] in trades_by_human:
+                        name_to_use = order_to_remove['Trader']
+                        trades_by_human[name_to_use].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Buy'})
+                    if trader in trades_by_informed_machine:
+                        trades_by_informed_machine[trader].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Sell'})
+                    if order_to_remove['Trader'] in trades_by_informed_machine:
+                        name_to_use = order_to_remove['Trader']
+                        trades_by_informed_machine[name_to_use].append({'Price': order_to_remove['Price'],
+                                                        'Amount': order_to_remove['Amount'],
+                                                        'Type': 'Buy'})
+
+        elif order_type == 'CANCEL_ORDER':
+            if direction == 'BID':
+                if orders['BIDS']:
+                    order_to_cancel = get_order_to_cancel(orders['BIDS'], trader, price)
+                    if order_to_cancel:
+                        orders['BIDS'].remove(order_to_cancel)
+                        total_cancellations +=1
+            else:
+                if orders['ASKS']:
+                    order_to_cancel = get_order_to_cancel(orders['ASKS'], trader, price)
+                    if order_to_cancel:
+                        orders['ASKS'].remove(order_to_cancel)
+                        total_cancellations +=1
+
+
+        best_bid_price = max((order['Price'] for order in orders['BIDS']), default=None)
+        best_ask_price = min((order['Price'] for order in orders['ASKS']), default=None)
+
+        best_ask_size = (
+            sum(order['Amount'] for order in orders['ASKS'] if order['Price'] == best_ask_price)
+            if best_ask_price is not None else None
+        )
+
+        best_bid_size = (
+            sum(order['Amount'] for order in orders['BIDS'] if order['Price'] == best_bid_price)
+            if best_bid_price is not None else None
+        )
+
+        order_book_i = pd.DataFrame({
+            'Timestamp': [timestamp],
+            'Bid_Price_1': [best_bid_price],
+            'Ask_Price_1': [best_ask_price],
+            'Bid_Size_1': [best_bid_size],
+            'Ask_Size_1': [best_ask_size],
+        })
+
+        order_book = pd.concat([order_book,order_book_i],axis=0)
+
+
+        if (best_bid_price is not None) and (best_ask_price is not None):
+            midprice = (best_bid_price + best_ask_price) / 2
+            all_best_bid_prices.append(best_bid_price)
+            all_best_ask_prices.append(best_ask_price)
+            all_midprices.append(midprice)
+
+
+    all_metrics = {'Total_Orders': message_df.shape[0],
+                   'Total_Trades': total_trades,
+                   'Total_Cancellations': total_cancellations,
+                   'Initial_Midprice': all_midprices[0],
+                   'Last_Midprice': all_midprices[-1],
+                   'Informed_Direction': informed_direction}
+
+    # get informed machine statistics
+    for trader in trades_by_informed_machine:
+        trades = trades_by_informed_machine[trader]
+        total_trades = sum(trade['Amount'] for trade in trades)
+        total_expenditure = sum(trade['Price'] for trade in trades)
+        informed_vwap = total_expenditure / total_trades
+        direction = trades[0]['Type']
+        if direction == 'Sell':
+            splippage = informed_vwap - all_metrics['Initial_Midprice']
+        if direction == 'Buy':
+            splippage = all_metrics['Initial_Midprice'] - informed_vwap
+        scaled_slippage = float(splippage / np.sqrt(total_trades))
+
+        all_metrics[trader] = {
+            'VWAP': round(informed_vwap,3),
+            'Slippage': round(splippage,3),
+            'Scaled_Slippage': round(scaled_slippage,3),
+            'Trades': int(total_trades)
+        }
+
+    for trader in trades_by_human:
+        trades_human_i = trades_by_human[trader]
+        all_amounts = []
+        all_prices = []
+
+        num_buy = 0
+        num_sell = 0
+        prices_buy = []
+        prices_sell = []
+        for trade in trades_human_i:
+            all_amounts.append(trade['Amount'])
+            all_prices.append(trade['Price'])
+            if trade['Type'] == 'Buy':
+                prices_buy.append(trade['Price'])
+                num_buy +=1
+            else:
+                prices_sell.append(trade['Price'])
+                num_sell +=1
+
+        total_trades_trader_i = sum(all_amounts)
+        trader_i_vwap = sum(all_prices) / total_trades_trader_i if total_trades_trader_i > 0 else 0
+
+        if num_buy == num_sell:
+            pnl_original = sum(prices_sell) - sum(prices_buy)
+            pnl_new = pnl_original
+            penalty_original = 0
+            penalty_new = 0
+        elif num_buy > num_sell:
+            prices_buy_rem = prices_buy[num_sell:]
+            vwap_prices_buy_rem = sum(prices_buy_rem) / len(prices_buy_rem)
+            penalty = sum([ price - 1 for price in prices_buy_rem])
+            pnl_new = sum(prices_sell) - sum(prices_buy) + penalty
+            penalty_new = (num_buy - num_sell) * (penalty/len(prices_buy_rem) -  np.mean(prices_buy_rem) )
+
+            pnl_original = sum(prices_sell) - sum(prices_buy) + (num_buy - num_sell) * (all_best_bid_prices[-1] - 2)
+            penalty_original = (num_buy - num_sell) * ((all_best_bid_prices[-1] - 2) - vwap_prices_buy_rem)
+        else:
+            prices_sell_rem = prices_sell[num_buy:]
+            vwap_prices_sell_rem = sum(prices_sell_rem) / len(prices_sell_rem)
+            penalty = sum([ price + 1 for price in prices_sell_rem])
+            # since num_sell > num_buy
+            # i need to buy the rest
+            pnl_new = sum(prices_sell) - sum(prices_buy) - penalty
+            penalty_new = (num_sell - num_buy) * (penalty/len(prices_sell_rem) -  np.mean(prices_sell_rem))
+
+            pnl_original = sum(prices_sell) - sum(prices_buy) - (num_sell - num_buy) * (all_best_ask_prices[-1] + 2)
+            penalty_original = (num_sell - num_buy) * (vwap_prices_sell_rem - (all_best_ask_prices[-1] + 2))
+
+        all_metrics[trader] = {'Trades': total_trades_trader_i,
+                               'VWAP': trader_i_vwap,
+                               'PnL_Original': pnl_original,
+                               'PnL_New': pnl_new,
+                               'Penalty_Original': penalty_original,
+                               'Penalty_New': penalty_new,
+                               'Num_Sell': num_sell,
+                               'Num_Buy': num_buy,
+                               'Prices_Sell': prices_sell,
+                               'Prices_Buy': prices_buy}
+
+    return message_df, all_metrics, order_book
+
+
+
+def calculate_trader_specific_metrics(trader_specific_metrics, general_metrics, trader_goal):
+    """Calculate trader-specific metrics based on trading activity and goals."""
+    # Store the original PnL
+    pnl_original = trader_specific_metrics['PnL_Original']
+    pnl_new = trader_specific_metrics['PnL_New']
+
+    # Calculate reward with scaling between 3 and 10 based on PnL
+    if isinstance(pnl_original, (int, float)):
+        max_pnl_possible = 20
+        max_gbp_to_give = 10
+        if pnl_original<0:
+            reward = 0
+        else:
+            ratio = pnl_original/max_pnl_possible
+            real_ratio = min(ratio,1)
+            reward = real_ratio * max_gbp_to_give
+        # # Clip PnL to [-100, 100] range
+        # capped_pnl = max(min(original_pnl, 100), -100)
+        # # Scale PnL from [-100, 100] to [0, 1]
+        # normalized_pnl = (capped_pnl + 100) / 200
+        # # Scale to [3, 10] range
+        # reward = 3 + (normalized_pnl * 7)
+    else:
+        reward = '-'
+
+    if trader_goal != 0:
+        if trader_goal > 0:
+            if trader_specific_metrics['Trades'] <= trader_goal:
+                remaining_trades = abs(abs(trader_goal) - abs(trader_specific_metrics['Trades']))
+                expenditure = trader_specific_metrics['VWAP'] * trader_specific_metrics['Trades']
+                total_expenditure = expenditure + remaining_trades * general_metrics['Last_Midprice'] * 1.5
+                penalized_vwap = total_expenditure/abs(trader_goal)
+                slippage = general_metrics['Initial_Midprice'] - penalized_vwap
+                slippage_scaled = (general_metrics['Initial_Midprice'] - penalized_vwap) / np.sqrt(abs(trader_goal))
+
+                trader_specific_metrics.update({
+                    'Remaining_Trades': remaining_trades,
+                    'Penalized_VWAP': penalized_vwap,
+                    'Slippage': slippage,
+                    'Slippage_Scaled': slippage_scaled,
+                    'PnL_Original': pnl_original,  # Keep original PnL
+                    'Reward': reward
+                })
+            else:
+                remaining_trades = abs(trader_goal) - abs(trader_specific_metrics['Trades'])
+                prices_buy = trader_specific_metrics['Prices_Buy']
+                expenditure = sum(prices_buy[0:abs(trader_goal)])
+                VWAP = expenditure / abs(trader_goal)
+                trader_specific_metrics['VWAP'] = VWAP
+                penalized_vwap = expenditure / abs(trader_goal)
+                slippage = general_metrics['Initial_Midprice'] - penalized_vwap
+                slippage_scaled = (general_metrics['Initial_Midprice'] - penalized_vwap) / np.sqrt(abs(trader_goal))
+
+                trader_specific_metrics.update({
+                    'Remaining_Trades': remaining_trades,
+                    'Penalized_VWAP': penalized_vwap,
+                    'Slippage': slippage,
+                    'Slippage_Scaled': slippage_scaled,
+                    'PnL_Original': pnl_original,
+                    'Reward': reward
+                })
+        else:
+            if trader_specific_metrics['Trades'] <= abs(trader_goal):
+                remaining_trades = abs(abs(trader_goal) - abs(trader_specific_metrics['Trades']))
+                expenditure = trader_specific_metrics['VWAP'] * trader_specific_metrics['Trades']
+                total_expenditure = expenditure + remaining_trades * general_metrics['Last_Midprice'] * 0.5
+                penalized_vwap = total_expenditure/abs(trader_goal)
+                slippage = penalized_vwap - general_metrics['Initial_Midprice']
+                slippage_scaled = (penalized_vwap - general_metrics['Initial_Midprice']) / np.sqrt(abs(trader_goal))
+
+                trader_specific_metrics.update({
+                    'Remaining_Trades': remaining_trades,
+                    'Penalized_VWAP': penalized_vwap,
+                    'Slippage': slippage,
+                    'Slippage_Scaled': slippage_scaled,
+                    'PnL_Original': pnl_original,
+                    'PnL_New': pnl_new,
+                    'Reward': reward
+                })
+            else:
+                remaining_trades = abs(trader_specific_metrics['Trades']) - abs(trader_goal)
+                prices_sell = trader_specific_metrics['Prices_Sell']
+                expenditure = sum(prices_sell[0:abs(trader_goal)])
+                VWAP = expenditure / abs(trader_goal)
+                trader_specific_metrics['VWAP'] = VWAP
+                penalized_vwap = expenditure / abs(trader_goal)
+                slippage = penalized_vwap - general_metrics['Initial_Midprice']
+                slippage_scaled = (penalized_vwap - general_metrics['Initial_Midprice']) / np.sqrt(abs(trader_goal))
+
+                trader_specific_metrics.update({
+                    'Remaining_Trades': remaining_trades,
+                    'Penalized_VWAP': penalized_vwap,
+                    'Slippage': slippage,
+                    'Slippage_Scaled': slippage_scaled,
+                    'PnL': pnl_original,
+                    'Reward': reward
+                })
+
+    else:
+        trader_specific_metrics.update({
+            'Remaining_Trades': abs(trader_specific_metrics['Num_Sell'] - trader_specific_metrics['Num_Buy']),
+            'VWAP': '-',
+            'Penalized_VWAP': '-',
+            'Slippage': '-',
+            'Slippage_Scaled': '-',
+            'PnL_Original': pnl_original,
+            'Reward': reward
+        })
+
+    return trader_specific_metrics
+
+if __name__ == '__main__':
+    location = '/Users/marioljonuzaj/Dropbox/InformationDisseminatationProject/Pilot Sessions/Pilot Session October/T6/Logfiles/'
+    logfile_name = location + 'SESSION_1761395103_ea141aff_trading.log'  # Replace with your log file path
+    market_id = logfile_name.split('/')[-1].split('_trading')[0]
+    print('logfile_name is:', logfile_name)
+    print('market_id is:', market_id)
+    logfile_to_message(logfile_name)
+    message_df, all_metrics, order_book = process_logfile(logfile_name)
+
+
+    print(all_metrics)
+    print(order_book)
+
+    #for value in all_metrics:
+    #    if 'HUMAN_' in value:
+    #        # Extract the rest of the string after 'Human_'
+    #        human_id = value.split('HUMAN_', 1)[1]
+    #    if 'INFORMED_' in value:
+    #        informed_id = value
+
+    #trader_specific_metrics = all_metrics["'HUMAN_" + human_id]
+
+
+    #trader_specific_metrics = calculate_trader_specific_metrics(trader_specific_metrics, all_metrics, 0)
+    #print(trader_specific_metrics)
+    #output_message_file = location  + market_id + '_' + 'message_book.csv'
+    #message_df.to_csv(output_message_file, index=False)
+
+    #output_metrics_file = location  + market_id + '_' + ' metrics.json'
+
+    # Save the dictionary to a JSON file
+    # with open(output_metrics_file, 'w') as json_file:
+    #     json.dump(all_metrics, json_file, indent=4)

--- a/analysis/real-sessions/generate_statistics_by_folder.py
+++ b/analysis/real-sessions/generate_statistics_by_folder.py
@@ -1,0 +1,152 @@
+import numpy as np
+import pandas as pd
+import os
+from datetime import datetime
+
+from functions import process_logfile, calculate_trader_specific_metrics
+
+from settings import (BASE_DIR, FOLDERS, DATE, INFORMED_PASSIVE,
+                      INFORMED_PAR_RATE, LOGFILES_SUBFOLDER,
+                      DAYSTATS_SUBFOLDER, ORDER_BOOKS_SUBFOLDER)
+
+folders = FOLDERS
+informed_passive = INFORMED_PASSIVE
+informed_par_rate = INFORMED_PAR_RATE
+date_of_session = DATE
+
+day_statistics = pd.DataFrame(columns=['Trader', 'Market', 'Informed_Direction', 'Informed_Passive', 'Informed_Participation_Rate',
+                                       'PnL_Original', 'PnL_New','PnL_Original_per_transaction','PnL_New_per_transaction',
+                                       'Penalty_Original','Penalty_New','Initial_Midprice', 'Last_Midprice',
+                                       'Informed_Machine_VWAP','Informed_Machine_Slippage',
+                                       'Informed_Machine_Scaled_Slippage', 'Informed_Machine_Trades',
+                                       'Human_VWAP_Buy','Human_VWAP_Sell','Human_Rem_Trades'])
+
+for index, folder in enumerate(folders):
+    print(folder)
+    logfiles_folder = os.path.join(BASE_DIR, folder, LOGFILES_SUBFOLDER)
+
+    orderbook_folder = os.path.join(BASE_DIR, folder, ORDER_BOOKS_SUBFOLDER)
+
+    log_files = [logfiles_folder + '/' + f for f in os.listdir(logfiles_folder) if f.endswith('.log')]
+    market_ids = [os.path.basename(p).replace('SESSION_', '').replace('MARKET_', '').replace('.log', '').replace('_', '_', 2) for p in log_files]
+
+    jj = 0
+    for logfile in log_files:
+        print(logfile)
+        jj += 1
+        market_id = market_ids[jj-1]
+        message_df, all_metrics, order_book = process_logfile(logfile)
+
+        human_id = None
+        informed_id = None
+        informed_direction = [all_metrics['Informed_Direction']]
+
+        for value in all_metrics:
+            if 'HUMAN_' in value:
+                # Extract the rest of the string after 'Human_'
+                human_id = value.split('HUMAN_', 1)[1]
+            if 'INFORMED_' in value:
+                informed_id = value
+
+
+        order_book['Midprice'] = (order_book['Bid_Price_1'] + order_book['Ask_Price_1']) / 2
+        order_book['Trader_IM'] = message_df['Trader'].values
+        order_book['Trader_IM_Price'] = message_df['Price'].values
+        order_book['Trader_IM_Amount'] = message_df['Amount'].values
+        order_book['Trader_IM_Direction'] = message_df['Direction'].values
+        order_book['Trader_IM_Type'] = message_df['Type'].values
+
+        order_book['Trader'] =  human_id[:-1] if human_id else None
+        order_book['Market'] = market_id
+        order_book['Treatment'] = folders[0]
+        order_book['Informed_Passive'] = informed_passive[0]
+        order_book['IPR'] = informed_par_rate[0]
+        order_book['Informed_Direction'] = informed_direction[0]
+
+        save_file_path_order_book = orderbook_folder + f'/{market_id}.csv'
+        order_book.to_csv(save_file_path_order_book, index=False)
+
+
+
+        if human_id is not None:
+            trader_specific_metrics = all_metrics["'HUMAN_" + human_id]
+            trader_specific_metrics = calculate_trader_specific_metrics(trader_specific_metrics, all_metrics, 0)
+
+            keep_human_pnl_original = trader_specific_metrics['PnL_Original']
+            keep_human_pnl_new = trader_specific_metrics['PnL_New']
+            keep_human_num_transactions = max(trader_specific_metrics['Num_Sell'] , trader_specific_metrics['Num_Buy'])
+            keep_penalty_original = trader_specific_metrics['Penalty_Original']
+            keep_penalty_new = trader_specific_metrics['Penalty_New']
+
+            keep_remaining_trades = trader_specific_metrics['Remaining_Trades']
+            human_vwap_buy = np.mean(trader_specific_metrics['Prices_Buy']) if trader_specific_metrics['Prices_Buy'] else 0
+            human_vwap_sell = np.mean(trader_specific_metrics['Prices_Sell']) if trader_specific_metrics['Prices_Sell'] else 0
+
+            if keep_human_num_transactions == 0:
+                keep_human_pnl_original_per_transaction = 0
+                keep_human_pnl_new_per_transaction = 0
+            else:
+                keep_human_pnl_original_per_transaction = np.round(keep_human_pnl_original / keep_human_num_transactions,3)
+                keep_human_pnl_new_per_transaction = np.round(keep_human_pnl_new / keep_human_num_transactions,3)
+        else:
+            human_id = 'no_human_'
+            keep_human_pnl_original = np.nan
+            keep_human_pnl_new = np.nan
+            keep_human_num_transactions = np.nan
+            keep_human_pnl_original_per_transaction = np.nan
+            keep_human_pnl_new_per_transaction = np.nan
+            keep_penalty_original = np.nan
+            keep_penalty_new = np.nan
+            human_vwap_buy = np.nan
+            human_vwap_sell = np.nan
+            keep_remaining_trades = np.nan
+
+        if informed_id is not None:
+            informed_machine_specific_metrics = all_metrics[informed_id]
+            informed_machine_vwap = informed_machine_specific_metrics['VWAP']
+            informed_machine_slippage = informed_machine_specific_metrics['Slippage']
+            informed_machine_scaled_slippage = informed_machine_specific_metrics['Scaled_Slippage']
+            informed_machine_trades = informed_machine_specific_metrics['Trades']
+        else:
+            informed_machine_specific_metrics = np.nan
+            informed_machine_vwap = np.nan
+            informed_machine_slippage = np.nan
+            informed_machine_scaled_slippage = np.nan
+            informed_machine_trades = np.nan
+
+        keep_initial_midprice = all_metrics['Initial_Midprice']
+        keep_last_midprice = all_metrics['Last_Midprice']
+        #keep_remaining_trades = trader_specific_metrics['Remaining_Trades']
+        #human_vwap_buy = np.mean(trader_specific_metrics['Prices_Buy']) if trader_specific_metrics['Prices_Buy'] else 0
+        #human_vwap_sell = np.mean(trader_specific_metrics['Prices_Sell']) if trader_specific_metrics['Prices_Sell'] else 0
+
+        new_row = pd.DataFrame({'Trader': [human_id[:-1]], 'Market': [market_id],
+                                'Informed_Direction': informed_direction[index],
+                                'Informed_Passive': informed_passive[index],
+                                'Informed_Participation_Rate': informed_par_rate[index],
+                                'PnL_Original': [keep_human_pnl_original],
+                                'PnL_New': [keep_human_pnl_new],
+                                'PnL_Original_per_transaction': [keep_human_pnl_original_per_transaction],
+                                'PnL_New_per_transaction': [keep_human_pnl_new_per_transaction],
+                                'Penalty_Original': [keep_penalty_original],
+                                'Penalty_New': [keep_penalty_new],
+                                'Initial_Midprice': [keep_initial_midprice],
+                                'Last_Midprice': [keep_last_midprice],
+                                'Informed_Machine_VWAP' : [informed_machine_vwap],
+                                'Informed_Machine_Slippage' : [informed_machine_slippage],
+                                'Informed_Machine_Scaled_Slippage': [informed_machine_scaled_slippage],
+                                'Informed_Machine_Trades': [informed_machine_trades],
+                                'Human_VWAP_Buy': [human_vwap_buy],
+                                'Human_Rem_Trades' : [keep_remaining_trades],
+                                'Human_VWAP_Sell': [human_vwap_sell],
+                                })
+
+
+        day_statistics = pd.concat([day_statistics, new_row], ignore_index=True)
+
+day_statistics_sorted = day_statistics.sort_values(by=['Trader','Market'])
+#filtered_df = day_statistics_sorted.groupby('Trader').apply(lambda group: group.iloc[1:]).reset_index(drop=True)
+print(day_statistics_sorted)
+save_file_path = os.path.join(BASE_DIR, folders[0], DAYSTATS_SUBFOLDER, f'all_{date_of_session}.csv')
+day_statistics_sorted.to_csv(save_file_path, index=False)
+# print(f"File saved to {save_file_path}")

--- a/analysis/real-sessions/main.py
+++ b/analysis/real-sessions/main.py
@@ -1,0 +1,30 @@
+"""
+Run the Real Sessions analysis pipeline end to end, in order:
+
+    1. generate_statistics_by_folder.py   raw Logfiles  -> all_<DATE>.csv
+    2. analysis.py                         all_<DATE>    -> filtered_<DATE>.csv, payment_<DATE>.csv
+    3. order_book.py                       filtered_<DATE> + Order_Books -> <FOLDER>_markets.csv, <FOLDER>_OB.csv
+
+Configure everything in settings.py first, then:
+
+    python main.py
+"""
+import os
+import runpy
+
+import settings
+
+SCRIPTS = [
+    'generate_statistics_by_folder.py',
+    'analysis.py',
+    'order_book.py',
+]
+
+if __name__ == '__main__':
+    here = os.path.dirname(os.path.abspath(__file__))
+    print(f"FOLDER = {settings.FOLDER}   DATE = {settings.DATE}")
+    print(f"BASE_DIR = {settings.BASE_DIR}")
+    for script in SCRIPTS:
+        print(f"\n===== running {script} =====", flush=True)
+        runpy.run_path(os.path.join(here, script), run_name='__main__')
+    print(f"\nDone. Outputs written to: {settings.DAYSTATS_DIR}")

--- a/analysis/real-sessions/order_book.py
+++ b/analysis/real-sessions/order_book.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+import os
+from datetime import datetime
+import random
+
+from settings import BASE_DIR, FOLDER, DATE, DAYSTATS_SUBFOLDER, ORDER_BOOKS_SUBFOLDER
+
+pathname = BASE_DIR
+folder = FOLDER
+
+filename = pathname + '/' + folder + '/'+ DAYSTATS_SUBFOLDER + '/'
+
+files = [f'filtered_{DATE}.csv']
+
+
+df = pd.read_csv(filename + files[0])
+
+
+order_book_markets_needed = list( df.loc[df.Trader != 'no_human']['Market'] )
+
+
+order_books_folder = pathname + '/' + folder + '/' + ORDER_BOOKS_SUBFOLDER
+# for file in os.listdir(order_books_folder):
+#     print(file)
+
+
+def pool_order_books(order_books_folder,order_book_markets_needed,filename_to_export):
+  all_df = pd.DataFrame()
+  for file in order_book_markets_needed:
+    filename_to_read = order_books_folder + '/' + f'{file}' + '.csv'
+    df = pd.read_csv(filename_to_read,header=0)
+    all_df = pd.concat([all_df,df],axis=0).reset_index(drop=True)
+
+  all_df.sort_values(by=['Trader', 'Market'], ascending=[True, True], inplace=True)
+  all_df.to_csv(filename_to_export,index=False)
+
+pool_order_books(order_books_folder,order_book_markets_needed,filename_to_export=filename + 'Udine_OB.csv')

--- a/analysis/real-sessions/settings.py
+++ b/analysis/real-sessions/settings.py
@@ -1,0 +1,48 @@
+"""
+Central configuration for the Real Sessions log-analysis pipeline.
+
+EDIT ONLY THIS FILE between sessions. Point BASE_DIR at the folder that
+contains the session subfolder (the one holding Logfiles/, Order_Books/,
+DayStatistics/), choose which subfolder + session date to analyse, then run:
+
+    python main.py
+
+The analysis scripts (generate_statistics_by_folder.py, analysis.py,
+order_book.py) read everything below from here, so nothing else needs to
+change when you analyse a new session.
+"""
+import os
+
+# === EDIT THESE FOR EACH SESSION ===========================================
+
+# Folder that contains the session subfolder (FOLDER below).
+# Examples:
+#   live Dropbox mount (make the session folder "available offline" first):
+#       BASE_DIR = os.path.expanduser(
+#           '~/Dropbox/InformationDisseminatationProject/Real Sessions Udine')
+#   a local folder you copied a session's data into:
+#       BASE_DIR = os.path.join(os.path.dirname(__file__), '_local_data')
+BASE_DIR = os.path.expanduser(
+    '~/Dropbox/InformationDisseminatationProject/Real Sessions Udine')
+
+# Which session subfolder to analyse, and the date used in file names
+# (all_<DATE>.csv, filtered_<DATE>.csv, ...).
+FOLDER = 'Treatments'
+DATE = '20260401'
+
+# Subfolder names inside FOLDER. These vary by session — check on disk.
+LOGFILES_SUBFOLDER = 'Logfiles'        # raw .log files
+DAYSTATS_SUBFOLDER = 'Daystatistics'   # all aggregate outputs are written here
+ORDER_BOOKS_SUBFOLDER = 'Order_Books'  # per-market order-book .csv files (built by stage 1)
+
+# Session metadata. Only used to label columns in all_<DATE>.csv (one entry
+# per folder in FOLDERS below); does not affect any computation.
+INFORMED_PASSIVE = ['Mixed']
+INFORMED_PAR_RATE = ['Mixed']
+
+# === DERIVED (no need to edit) =============================================
+FOLDERS = [FOLDER]
+FOLDER_DIR = os.path.join(BASE_DIR, FOLDER)
+LOGFILES_DIR = os.path.join(FOLDER_DIR, LOGFILES_SUBFOLDER)
+DAYSTATS_DIR = os.path.join(FOLDER_DIR, DAYSTATS_SUBFOLDER)
+ORDER_BOOKS_DIR = os.path.join(FOLDER_DIR, ORDER_BOOKS_SUBFOLDER)


### PR DESCRIPTION
Ref #70

Integrates the Real Sessions (Udine) log-analysis scripts into the repo so anyone can run them, per the original request.

## What
- New `analysis/real-sessions/`: Alessio's scripts verbatim + `settings.py` (centralised config) + `main.py` (runs generate -> analysis -> order_book).
- Source = the latest Dropbox copies `Real Sessions Udine/Treatments/Codes/` (April 2026).
- `.gitignore` carve-out (`/analysis/* ` + `!/analysis/real-sessions/`) so the code is tracked while logs / CSVs / `_local_data/` stay out (human-subjects data).

## Changes to the original scripts (minimal)
- hardcoded paths / folder / date / filenames -> imported from `settings.py`;
- two backward-compatible pandas-3.0 fixes in `analysis.py` (`groupby().apply()` -> `df[df['Id']!=0]` and a vectorised no-human relabel) — identical output on old and new pandas; analysis logic otherwise untouched.

## Verification
Ran all three stages end-to-end on local current-format logs (`data/experiment_logs_20260401`): produced `all_/filtered_/payment_/Udine_OB.csv` + per-market `Order_Books/*.csv`. Unique market_id, handles no-human markets.

## To run on real data
Point `settings.BASE_DIR` at a session made "available offline" in the Dropbox app, then `python main.py`.
