### PR TITLE
Log participant identity server-side at market start

### DIFF
--- a/analysis/real-sessions/functions.py
+++ b/analysis/real-sessions/functions.py
@@ -85,7 +85,7 @@ def logfile_to_message(logfile_name):
                 timestamp_save.append(timestamp_str)
                 type_save.append(msg_type)
 
-            if msg_type == 'RECORD_KEEPING_ORDER':
+            if msg_type in ('RECORD_KEEPING_ORDER', 'PARTICIPANT_REGISTERED'):
                 trader_key = "'trader_id': "
                 start_index = msg_content.index(trader_key) + len(trader_key)
                 end_index = msg_content.index(',', start_index)

--- a/back/core/trader_manager.py
+++ b/back/core/trader_manager.py
@@ -161,6 +161,11 @@ class TraderManager:
             while len(self.human_traders) < num_required_traders:
                 await asyncio.sleep(1)
 
+        for ht in self.human_traders:
+            self.trading_market.orchestrator.trading_logger.info(
+                f"PARTICIPANT_REGISTERED: {{'trader_id': '{ht.id}', 'gmail_username': '{ht.gmail_username}', 'role': '{ht.role}', 'goal': {ht.goal}}}"
+            )
+
         await self.trading_market.start_trading()
 
         trading_market_task = asyncio.create_task(self.trading_market.run())


### PR DESCRIPTION
Ensures a market's `.log` file records who was in it, even for participants who place zero trades.

## Background
The zero-amount `RECORD_KEEPING_ORDER` (intended to log non-trading participants) never fires: `TRADING_STARTED` is broadcast via `send_to_traders()`, which only reaches already-registered traders, but the Socket.IO `join_market` handler waits for `trading_started` before registering the human. So the human is registered strictly after the event — `handle_TRADING_STARTED` never runs for them.

## Changes
- `trader_manager.py`: write a `PARTICIPANT_REGISTERED` log line for each human trader at market start (server-side, before trading begins). Independent of Socket.IO timing.
- `analysis/real-sessions/functions.py`: parse `PARTICIPANT_REGISTERED` alongside `RECORD_KEEPING_ORDER`.

## Reproduction (local)
| | participant identity in `.log` |
|---|---|
| Before | absent (0 HUMAN / 0 RECORD_KEEPING lines) |
| After | present (PARTICIPANT_REGISTERED per participant) |

Note: per discussion in #73, the same mapping also exists in `parameter_history.json`; this change makes each `.log` self-describing so identity doesn't depend on a separate file.

Ref #73