### PR TITLE
fix: nanosecond lab market_id to prevent log file collisions (#76)

### DIFF
--- a/back/core/session_manager.py
+++ b/back/core/session_manager.py
@@ -173,10 +173,13 @@ class SessionManager:
                 merged = treatment_manager.get_merged_params(applied_treatment_index, base_params_dict)
 
             params = TradingParameters(**merged)
-            # Lab room keys are short (T0_M0), so append timestamp for uniqueness.
+            # Lab room keys are short (T0_M0), so append a timestamp for uniqueness.
+            # Use nanoseconds, not seconds: two participants can start markets within
+            # the same wall-clock second, and int-second suffixes then collide into one
+            # market_id -> one shared log file, corrupting/losing per-market logs (#76).
             # Prolific room keys already contain a timestamp, so use as-is.
             if session_id.startswith("T"):
-                timestamped_id = f"{session_id}_{int(time.time())}"
+                timestamped_id = f"{session_id}_{time.time_ns()}"
             else:
                 timestamped_id = session_id
             trader_manager = TraderManager(params, market_id=timestamped_id)

--- a/back/utils/utils.py
+++ b/back/utils/utils.py
@@ -35,6 +35,12 @@ def setup_trading_logger(market_id: str) -> logging.Logger:
     logger = logging.getLogger(f"trading_market_{market_id}")
     logger.setLevel(logging.INFO)
 
+    # getLogger returns a singleton per name; guard against attaching a second
+    # FileHandler if this market_id's logger was already configured. Otherwise a
+    # reused market_id makes every log line be written once per handler (#76).
+    if logger.handlers:
+        return logger
+
     log_dir = "logs"
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, f"{market_id}.log")


### PR DESCRIPTION
## Problem

Lab market ids were `T{t}_M{n}_{int(time.time())}` — **second resolution**. When two participants start markets within the same wall-clock second they get the **same `market_id`**, hence the same `logs/{market_id}.log` file. Because `FileHandler` appends and `getLogger` is a singleton per name, the two markets' logs **interleave** (and every line is duplicated once per collided market), so per-market logs are corrupted or effectively lost. Same root cause as #72.

## Live reproduction (Docker, on top of #74)

Fired 12 fresh solo `TREATMENT=0` markets back-to-back:

| | markets | distinct market_ids | `.log` files |
|---|---|---|---|
| **before** (main incl. #74) | 12 | **3** | 3 |
| **after** (this PR) | 12 | **12** | 12 |

The collided files showed a triangular-number signature (7 markets → 28 duplicated book-init lines = 1+2+…+7; 5 → 15), confirming both the filename collision and the duplicate-handler amplification. #74's lock does **not** prevent this — it reproduces with sequential starts, so it is a distinct bug.

## Fix

- `session_manager`: use `time.time_ns()` so same-second starts get unique ids.
- `utils.setup_trading_logger`: return early if the logger already has handlers, so a reused `market_id` can't attach duplicate `FileHandler`s (defense-in-depth).

Nothing parses epoch-seconds back out of a `market_id`, so the longer suffix is safe.

## Tests

The 3 pre-existing `test_session_manager` failures fail identically on `main` (stale tests vs. the non-lab room-key refactor); this PR does not change them.

Ref #76
