### PR TITLE
issue #78 (2/4): rename 'Market Reward (if selected)' to 'Market Reward'

### DIFF
--- a/front/src/components/market/MarketSummary.vue
+++ b/front/src/components/market/MarketSummary.vue
@@ -27,7 +27,7 @@
                 }}</span>
               </div>
               <div class="stat-row">
-                <span class="stat-name">Market Reward (if selected)</span>
+                <span class="stat-name">Market Reward</span>
                 <span class="stat-val">{{
                   formatValue(traderSpecificMetrics.Reward, 'gbp')
                 }}</span>


### PR DESCRIPTION
Part of #78 (point 2 of 4). One-line label change on the market summary page.

**Before:** the per-market stats row on the summary page read `Market Reward (if selected)`.
**After:** it reads `Market Reward`.

The "(if selected)" qualifier described the old payment scheme (one randomly selected market pays). It becomes wrong once the final payment is the average over all markets — that scheme change lands separately in the follow-up PR for point 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)