### PR TITLE
issue #78 (4/4 scope, PR 2 of 4): lift the £10 cap on no-goal trader rewards

### DIFF
--- a/analysis/real-sessions/analysis.py
+++ b/analysis/real-sessions/analysis.py
@@ -16,6 +16,10 @@ date_of_session = DATE
 
 RANDOM_STATE = 123
 
+# Per-market payment cap in CCY (issue #78): was 10, now set very high to
+# effectively disable it while retaining the capping code path.
+PAYMENT_CAP_CCY = 1_000_000
+
 save_dir = os.path.join(pathname, folder, DAYSTATS_SUBFOLDER)
 os.makedirs(save_dir, exist_ok=True)
 
@@ -99,7 +103,7 @@ df_filtered_final_payment = df_filtered_final_payment[
 
 df_filtered_final_payment[CCY] = (
     df_filtered_final_payment['PnL_Original'] / CONVERSION_RATE
-).clip(lower=0, upper=10)
+).clip(lower=0, upper=PAYMENT_CAP_CCY)
 
 
 save_file_path = os.path.join(save_dir, f'payment_{date_of_session}.csv')

--- a/back/tests/test_reward_calculation.py
+++ b/back/tests/test_reward_calculation.py
@@ -15,7 +15,31 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from utils.logfiles_analysis import calculate_vwap_reward
+from utils.logfiles_analysis import calculate_vwap_reward, calculate_trader_specific_metrics
+
+
+class TestNoGoalRewardCap:
+    """No-goal (speculator) reward: floored at 0, cap effectively disabled (issue #78)."""
+
+    def _reward_for_pnl(self, pnl, conversion_rate=2):
+        metrics = calculate_trader_specific_metrics(
+            {"PnL": pnl, "Trades": 4, "Num_Buy": 2, "Num_Sell": 2,
+             "VWAP": 100, "Prices_Buy": [100, 100], "Prices_Sell": [100, 100]},
+            {}, trader_goal=0, conversion_rate=conversion_rate)
+        return metrics["Reward"]
+
+    def test_negative_pnl_floored_to_zero(self):
+        assert self._reward_for_pnl(-200) == 0
+
+    def test_positive_pnl_converts_linearly(self):
+        # PnL / conversion_rate, no longer clipped at 10
+        assert self._reward_for_pnl(10) == pytest.approx(5.0)
+        assert self._reward_for_pnl(20) == pytest.approx(10.0)
+
+    def test_old_cap_no_longer_binds(self):
+        """Was capped at 10 GBP; PnL of 50 Lira must now pay 25 GBP."""
+        assert self._reward_for_pnl(50) == pytest.approx(25.0)
+        assert self._reward_for_pnl(100) == pytest.approx(50.0)
 
 
 class TestBasicRewardCalculation:

--- a/back/utils/logfiles_analysis.py
+++ b/back/utils/logfiles_analysis.py
@@ -15,6 +15,11 @@ import json
 from datetime import datetime
 from typing import Optional
 
+# Cap (in GBP) on the per-market reward of no-goal (speculator) traders.
+# Was 10; set very high to effectively disable it while retaining the capping
+# code path (issue #78). Goal traders were never capped.
+MAX_GBP_TO_GIVE = 1_000_000
+
 
 def calculate_vwap_reward(
     goal: int,
@@ -518,16 +523,16 @@ def calculate_trader_specific_metrics(trader_specific_metrics, general_metrics, 
     # Store the original PnL
     original_pnl = trader_specific_metrics['PnL']
     
-    # Calculate reward with scaling between 3 and 10 based on PnL (for no-goal traders)
+    # Reward for no-goal traders: PnL converted to GBP, floored at 0 and
+    # capped at MAX_GBP_TO_GIVE (currently set high enough to never bind).
     if isinstance(original_pnl, (int, float)):
-        max_pnl_possible = 10 * conversion_rate
-        max_gbp_to_give = 10
+        max_pnl_possible = MAX_GBP_TO_GIVE * conversion_rate
         if original_pnl < 0:
             reward = 0
         else:
             ratio = original_pnl / max_pnl_possible
             real_ratio = min(ratio, 1)
-            reward = real_ratio * max_gbp_to_give
+            reward = real_ratio * MAX_GBP_TO_GIVE
     else:
         reward = '-'
     

--- a/front/public/instructions/instructions.md
+++ b/front/public/instructions/instructions.md
@@ -128,8 +128,6 @@ Liras at the end minus {initialCash}
 
 Your earnings will be converted at the rate of 2 Liras = 1 Euro.
 
-For each market, earnings will be capped at a maximum of 10 Euro.
-
 Losses are capped to 0
 
 Total earnings = 5 Euro + earnings from randomly selected market


### PR DESCRIPTION
Part of #78 (point 4). The per-market reward cap for no-goal (speculator) traders is effectively removed, implemented as a configurable constant as requested.

**Where the cap lives now (as asked in the issue):**
- Platform: `MAX_GBP_TO_GIVE` at the top of `back/utils/logfiles_analysis.py` (was a hard-coded `10` inside `calculate_trader_specific_metrics`)
- Offline payment pipeline: `PAYMENT_CAP_CCY` at the top of `analysis/real-sessions/analysis.py` (was `.clip(lower=0, upper=10)`)

Both are set to `1_000_000` so the capping code path is retained and the old behaviour is one edit away.

**Before** (real `calculate_trader_specific_metrics`, conversion_rate=2 — cap binds from PnL = 20 Lira):
```
PnL  -200 Lira -> Reward £0
PnL    20 Lira -> Reward £10.0
PnL    50 Lira -> Reward £10      <- capped
PnL   100 Lira -> Reward £10      <- capped
```
**After:**
```
PnL  -200 Lira -> Reward £0       <- floor at 0 unchanged
PnL    20 Lira -> Reward £10.0
PnL    50 Lira -> Reward £25.0
PnL   100 Lira -> Reward £50.0
```

Notes:
- Goal traders were never capped (`calculate_vwap_reward` is `max(0, pnl/10)`), so this also removes an asymmetry between the two trader types.
- The floor at 0 is untouched.
- The "capped at a maximum of 10 Euro" sentence is removed from the participant instructions (`front/public/instructions/instructions.md`).
- New tests: `TestNoGoalRewardCap` (3 tests). Full reward suite passes (21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)