### PR TITLE
issue #78 (3/4): final payment = average of positive per-market rewards

### DIFF
--- a/analysis/real-sessions/analysis.py
+++ b/analysis/real-sessions/analysis.py
@@ -88,22 +88,32 @@ df_filtered_final.loc[_nohuman_mask, 'Trader'] = (
 
 df_filtered_final.to_csv(save_file_path, index=False)
 
-# Randomly select one paying market per participant,
-# excluding the training market M0.
-df_filtered_final_payment = (
-    df_filtered_final[df_filtered_final['Trader'] != NON_HUMAN_LABEL]
-    .groupby('Trader', group_keys=False)
-    .sample(n=1, random_state=RANDOM_STATE )
-    .reset_index(drop=True)
-)
-
-df_filtered_final_payment = df_filtered_final_payment[
-    ['Trader', 'Market', 'Id', 'PnL_Original']
-]
-
-df_filtered_final_payment[CCY] = (
-    df_filtered_final_payment['PnL_Original'] / CONVERSION_RATE
+# Payment = average of max(per-market earnings, 0) over all non-practice
+# markets (issue #78). This replaces the random selection of a single paying
+# market and must stay in sync with Accumulated_Reward on the platform
+# (back/api/routes/trading.py).
+# Old behaviour, kept for reference:
+# df_filtered_final_payment = (
+#     df_filtered_final[df_filtered_final['Trader'] != NON_HUMAN_LABEL]
+#     .groupby('Trader', group_keys=False)
+#     .sample(n=1, random_state=RANDOM_STATE )
+#     .reset_index(drop=True)
+# )
+# df_filtered_final_payment[CCY] = (
+#     df_filtered_final_payment['PnL_Original'] / CONVERSION_RATE
+# ).clip(lower=0, upper=10)
+df_payment_base = df_filtered_final[
+    df_filtered_final['Trader'] != NON_HUMAN_LABEL
+].copy()
+df_payment_base[CCY] = (
+    df_payment_base['PnL_Original'] / CONVERSION_RATE
 ).clip(lower=0, upper=PAYMENT_CAP_CCY)
+
+df_filtered_final_payment = (
+    df_payment_base
+    .groupby('Trader', as_index=False)
+    .agg(**{'Markets': ('Id', 'nunique'), CCY: (CCY, 'mean')})
+)
 
 
 save_file_path = os.path.join(save_dir, f'payment_{date_of_session}.csv')

--- a/back/api/random_picker.py
+++ b/back/api/random_picker.py
@@ -1,9 +1,0 @@
-import random
-
-def pick_random_element_new(input_list):
-    # use seed 2025 for consistent random selection
-    if not input_list:
-        raise ValueError("cannot pick from empty list")
-    random.seed(2025)
-    return random.choice(input_list)
-

--- a/back/api/reward_aggregation.py
+++ b/back/api/reward_aggregation.py
@@ -1,0 +1,10 @@
+def average_positive_rewards(rewards):
+    """Average of max(reward, 0) over the given markets (issue #78).
+
+    Replaces the seeded random pick of a single paying market. Rewards are
+    floored at 0 per market before averaging, so one bad market cannot drag
+    the payment below what the other markets earned.
+    """
+    if not rewards:
+        return 0
+    return sum(max(reward, 0) for reward in rewards) / len(rewards)

--- a/back/api/routes/trading.py
+++ b/back/api/routes/trading.py
@@ -21,7 +21,7 @@ from ..shared import (
 from utils.api_responses import success, waiting, not_in_session
 from utils.logfiles_analysis import order_book_contruction, calculate_trader_specific_metrics
 from utils.calculate_metrics import process_log_file, write_to_csv
-from ..random_picker import pick_random_element_new
+from ..reward_aggregation import average_positive_rewards
 
 router = APIRouter()
 
@@ -212,21 +212,28 @@ async def get_trader_info(trader_id: str):
                     trader_specific_metrics = calculate_trader_specific_metrics(
                         trader_specific_metrics, general_metrics, trader_goal, conversion_rate
                     )
-                    if isinstance(trader_specific_metrics.get('Reward'), (int, float)):
-                        if trader_id not in accumulated_rewards:
-                            accumulated_rewards[trader_id] = {}
-                        accumulated_rewards[trader_id][internal_session_id] = trader_specific_metrics['Reward']
-
-                    all_rewards = list(accumulated_rewards.get(trader_id, {}).values())
-                    if len(all_rewards) <= 1:
-                        trader_specific_metrics['Accumulated_Reward'] = 0
-                    else:
-                        trader_specific_metrics['Accumulated_Reward'] = pick_random_element_new(all_rewards[1:])
                 else:
                     trader_specific_metrics = {
                         'Trades': 0, 'Num_Buy': 0, 'Num_Sell': 0, 'Remaining_Trades': 0,
-                        'PnL': 0, 'Reward': 0, 'Accumulated_Reward': 0,
+                        'PnL': 0, 'Reward': 0,
                     }
+
+                # Record this market for the trader. Markets where the trader
+                # never traded still count as 0-reward markets (issue #78) —
+                # they used to vanish from the payment pool entirely.
+                reward = trader_specific_metrics.get('Reward')
+                if not isinstance(reward, (int, float)):
+                    reward = 0
+                accumulated_rewards.setdefault(trader_id, {})[internal_session_id] = reward
+
+                # Final payment: average of max(reward, 0) over all markets
+                # except the first (practice) one (issue #78; replaces the
+                # seeded random pick of a single market).
+                all_rewards = list(accumulated_rewards.get(trader_id, {}).values())
+                if len(all_rewards) <= 1:
+                    trader_specific_metrics['Accumulated_Reward'] = 0
+                else:
+                    trader_specific_metrics['Accumulated_Reward'] = average_positive_rewards(all_rewards[1:])
             else:
                 order_book_metrics = {}
                 trader_specific_metrics = {}

--- a/back/tests/test_reward_calculation.py
+++ b/back/tests/test_reward_calculation.py
@@ -15,6 +15,7 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from api.reward_aggregation import average_positive_rewards
 from utils.logfiles_analysis import calculate_vwap_reward, calculate_trader_specific_metrics
 
 
@@ -246,7 +247,7 @@ class TestAccumulatedRewards:
         if len(all_rewards) <= 1:
             accumulated = 0
         else:
-            accumulated = sum(all_rewards[1:])  # Simplified - actual uses random pick
+            accumulated = average_positive_rewards(all_rewards[1:])
 
         assert accumulated == 0
         print(f"✓ Single market: accumulated_reward=0 (first market skipped)")
@@ -299,6 +300,27 @@ class TestAccumulatedRewards:
         assert 0.0 in rewards_after_first
         assert len(rewards_after_first) == 3
         print(f"✓ Zero trades market included: {rewards_after_first}")
+
+
+class TestAveragePositiveRewards:
+    """Final payment = average of max(reward, 0) across markets (issue #78)."""
+
+    def test_issue_78_example(self):
+        """The example from the issue: 2,1,1,1,-200 -> mean(2,1,1,1,0) = 1."""
+        assert average_positive_rewards([2, 1, 1, 1, -200]) == 1
+
+    def test_all_positive(self):
+        assert average_positive_rewards([8.0, 0, 0, 9.0, 9.0]) == pytest.approx(5.2)
+
+    def test_empty_list(self):
+        assert average_positive_rewards([]) == 0
+
+    def test_single_market(self):
+        assert average_positive_rewards([7.5]) == 7.5
+
+    def test_zero_trade_market_counts_in_denominator(self):
+        """A played-but-untraded market drags the average down as a 0."""
+        assert average_positive_rewards([10.0, 0]) == 5.0
 
 
 class TestEdgeCases:

--- a/front/public/instructions/instructions.md
+++ b/front/public/instructions/instructions.md
@@ -120,17 +120,17 @@ If you had bought earlier, you could have bought at 110. Your profits are reduce
 
 <br>
 
-At the end of the study, you will receive the earnings from one randomly selected market.
+At the end of the study, you will receive the average of your earnings across all markets (excluding the practice market).
 
-Your earnings correspond to the difference between the lire held at the end and the Liras held at the beginning:
+Your earnings in each market correspond to the difference between the lire held at the end and the Liras held at the beginning:
 
 Liras at the end minus {initialCash}
 
 Your earnings will be converted at the rate of 2 Liras = 1 Euro.
 
-Losses are capped to 0
+Losses in a market are capped to 0, so a market with negative earnings counts as zero in the average.
 
-Total earnings = 5 Euro + earnings from randomly selected market
+Total earnings = 5 Euro + average market earnings
 
 Your earnings will be paid to you in Amazon vouchers. The transfer may take a few working days.
 

--- a/front/src/assets/trading-instructions.md
+++ b/front/src/assets/trading-instructions.md
@@ -67,7 +67,7 @@ If you do not achieve the objective within the time limit of the market the trad
   - Market earnings = (Number of shares) \* (mid-price at the beginning of the market) – total expense of purchases (incl. automatically bought shares)
   - The market price might rise above the mid-price at the beginning of the market. If that happens each purchase of a share will make a loss. However buying the shares is still in your interest as not buying them would create an even more significant loss. To cover your losses you will given # Liras at the beginning of each market.
 
-At the end of the study you will be awarded earnings from one randomly selected market. Your earnings in the chosen market are converted into GBP and paid to you. The conversion rate is X Liras = 1 GBP.
+At the end of the study you will be awarded the average of your earnings across all markets (excluding the practice market); a market with negative earnings counts as zero in the average. Your average earnings are converted into GBP and paid to you. The conversion rate is X Liras = 1 GBP.
 
 ### Page 6: Other Participants in the Market
 
@@ -84,9 +84,9 @@ After answering some control questions you will practice trading to familiarise 
 5. Your task is either to sell or buy shares. To maximise your earnings you must complete the task. (Correct/Incorrect)
 6. Your earnings are the sum of the earnings in all markets. (correct/incorrect)
 
-Let us assume a market is selected in which you had the task of selling all your 10 shares and you received 50 Lira at the start. You sold all the 10 shares for an average price of 11. The price at the beginning of the market was 12. What would be your earnings in Lira at the end of this market? (40 Lira)
+Consider a market in which you had the task of selling all your 10 shares and you received 50 Lira at the start. You sold all the 10 shares for an average price of 11. The price at the beginning of the market was 12. What would be your earnings in Lira at the end of this market? (40 Lira)
 
-Let us assume a market is selected in which you had the task of buying 10 shares and you received 60 Lira at the start. You bought 10 shares for an average price of 11. The price at the beginning of the market was 10. What would be your earnings in Lira at the end of this market? (50 Lira)
+Consider a market in which you had the task of buying 10 shares and you received 60 Lira at the start. You bought 10 shares for an average price of 11. The price at the beginning of the market was 10. What would be your earnings in Lira at the end of this market? (50 Lira)
 
 ### Page 8: Practice
 


### PR DESCRIPTION
Part of #78 (point 3). Replaces the random-market payment with the average requested in the issue, on both the platform and the offline payment pipeline.

**Formula:** `Accumulated_Reward = mean(max(reward_m, 0))` over all markets except the practice one — exactly the issue's `np.nanmean(np.maximum(MarketRewards, 0))`. The issue's own example is now a unit test: rewards `[2, 1, 1, 1, -200]` → payment `1.0`.

**What the 'random' selection actually did (before):** `pick_random_element_new` re-seeded `random.seed(2025)` on every call, so the pick was a fixed index depending only on list length — always the **last** market for a clean 5-market session (what asancetta observed), and e.g. always the *first* for a 4-market pool. Verified by calling the real function 1000×.

**A second bug this fixes:** markets where the participant never traded were silently absent from the payment pool. E2E before-run (markets 1–5, rewards 8.0 / — / 0 / 9.0 / 9.0 where market 2 had zero trades): the pool held only 4 entries and the seeded pick paid market 1 (£8.00). After: zero-trade markets count as £0 in numerator and denominator.

**E2E before/after** (same scripted 6-market session, one participant, goal buy-2):
| | final number shown |
|---|---|
| before | £8.00 (deterministic pick) |
| after | £5.10 = mean(8.5, 0, 0, 8.5, 8.5) |

Notes for review:
- Per-market rewards are already floored at 0 by both reward formulas, so the `max(·, 0)` inside the average is defensive — a reward like the issue's `-200` cannot currently occur (PnL can be negative; the per-market *reward* cannot). Negative-PnL markets enter the average as £0.
- `back/api/random_picker.py` is deleted (dead after this change; git history keeps it).
- Participant instructions updated to describe the average scheme (`front/public/instructions/instructions.md`, `front/src/assets/trading-instructions.md`) — @asancetta please review the wording.
- `analysis/real-sessions/analysis.py` now emits `payment_<date>.csv` as per-trader mean of `clip(PnL/CONVERSION_RATE, 0, PAYMENT_CAP_CCY)` over non-practice markets, replacing `.sample(n=1, random_state=123)` (old block kept commented for reference).
- New tests: `TestAveragePositiveRewards` (5 tests); suite passes (26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)