### PR TITLE
issue #78 (1/4 scope, final PR): end-of-session summary shows all markets

### DIFF
--- a/back/api/routes/admin.py
+++ b/back/api/routes/admin.py
@@ -11,7 +11,7 @@ from core.data_models import TradingParameters
 from core.trader_manager import TraderManager
 from core.treatment_manager import treatment_manager
 from ..auth import get_current_user, get_current_admin_user
-from ..shared import base_settings, market_handler, accumulated_rewards
+from ..shared import base_settings, market_handler, accumulated_rewards, accumulated_market_stats
 from utils.api_responses import success, not_found
 from .questionnaire import clear_questionnaire_data
 
@@ -101,6 +101,7 @@ async def reset_state(current_user: dict = Depends(get_current_admin_user)):
         await market_handler.reset_state()
         base_settings.update(current_settings)
         accumulated_rewards.clear()
+        accumulated_market_stats.clear()
         clear_questionnaire_data()
         return success(message="Application state reset successfully")
     except Exception:
@@ -115,6 +116,7 @@ async def test_reset_state():
         await market_handler.reset_state()
         base_settings.update(current_settings)
         accumulated_rewards.clear()
+        accumulated_market_stats.clear()
         clear_questionnaire_data()
         return success(message="Test reset completed (including historical markets)")
     except Exception as e:

--- a/back/api/routes/trading.py
+++ b/back/api/routes/trading.py
@@ -15,7 +15,7 @@ from core.trader_manager import TraderManager
 from core.data_models import TradingParameters
 from ..auth import get_current_user
 from ..shared import (
-    base_settings, market_handler, accumulated_rewards,
+    base_settings, market_handler, accumulated_rewards, accumulated_market_stats,
     get_historical_markets_count,
 )
 from utils.api_responses import success, waiting, not_in_session
@@ -225,6 +225,12 @@ async def get_trader_info(trader_id: str):
                 if not isinstance(reward, (int, float)):
                     reward = 0
                 accumulated_rewards.setdefault(trader_id, {})[internal_session_id] = reward
+                accumulated_market_stats.setdefault(trader_id, {})[internal_session_id] = {
+                    'Trades': trader_specific_metrics.get('Trades', 0),
+                    'Remaining_Trades': trader_specific_metrics.get('Remaining_Trades', 0),
+                    'PnL': trader_specific_metrics.get('PnL', 0),
+                    'Reward': reward,
+                }
 
                 # Final payment: average of max(reward, 0) over all markets
                 # except the first (practice) one (issue #78; replaces the
@@ -234,6 +240,15 @@ async def get_trader_info(trader_id: str):
                     trader_specific_metrics['Accumulated_Reward'] = 0
                 else:
                     trader_specific_metrics['Accumulated_Reward'] = average_positive_rewards(all_rewards[1:])
+
+                # Chronological per-market history for the summary table
+                # (market 0 is the practice market).
+                trader_specific_metrics['Market_History'] = [
+                    {'market': market_number, **stats_snapshot}
+                    for market_number, stats_snapshot in enumerate(
+                        accumulated_market_stats.get(trader_id, {}).values()
+                    )
+                ]
             else:
                 order_book_metrics = {}
                 trader_specific_metrics = {}

--- a/back/api/shared.py
+++ b/back/api/shared.py
@@ -18,6 +18,9 @@ base_settings = default_params.model_dump()
 # Store accumulated rewards per user
 accumulated_rewards: Dict[str, dict] = {}
 
+# Per-market stats snapshots per user (drives the end-of-session summary table)
+accumulated_market_stats: Dict[str, dict] = {}
+
 # Central market handler (owns session_manager, trader_managers, etc.)
 market_handler = SimpleMarketHandler()
 

--- a/front/src/components/market/MarketSummary.vue
+++ b/front/src/components/market/MarketSummary.vue
@@ -8,30 +8,70 @@
             <!-- Your Statistics -->
             <div v-if="traderSpecificMetrics" class="stat-section">
               <div class="section-label">Your Statistics</div>
-              <div class="stat-row">
-                <span class="stat-name">Your Trades</span>
-                <span class="stat-val">{{
-                  formatValue(traderSpecificMetrics.Trades, 'number')
-                }}</span>
+              <!-- End of session: one column per market (practice market excluded) -->
+              <div v-if="isLastMarket && marketHistory.length" class="stat-table-wrap">
+                <table class="stat-table">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th v-for="m in marketHistory" :key="m.market">Market {{ m.market }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="stat-name">Your Trades</td>
+                      <td v-for="m in marketHistory" :key="m.market" class="stat-val">
+                        {{ formatValue(m.Trades, 'number') }}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="stat-name">Inventory Imbalance</td>
+                      <td v-for="m in marketHistory" :key="m.market" class="stat-val">
+                        {{ formatValue(m.Remaining_Trades, 'number') }}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="stat-name">PnL</td>
+                      <td v-for="m in marketHistory" :key="m.market" class="stat-val">
+                        {{ formatValue(m.PnL, 'number') }}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="stat-name">Market Reward</td>
+                      <td v-for="m in marketHistory" :key="m.market" class="stat-val">
+                        {{ formatValue(m.Reward, 'gbp') }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
-              <div class="stat-row">
-                <span class="stat-name">Inventory Imbalance</span>
-                <span class="stat-val">{{
-                  formatValue(traderSpecificMetrics.Remaining_Trades, 'number')
-                }}</span>
-              </div>
-              <div class="stat-row">
-                <span class="stat-name">PnL</span>
-                <span class="stat-val">{{
-                  formatValue(traderSpecificMetrics.PnL, 'number')
-                }}</span>
-              </div>
-              <div class="stat-row">
-                <span class="stat-name">Market Reward</span>
-                <span class="stat-val">{{
-                  formatValue(traderSpecificMetrics.Reward, 'gbp')
-                }}</span>
-              </div>
+              <!-- During the session: the market just played -->
+              <template v-else>
+                <div class="stat-row">
+                  <span class="stat-name">Your Trades</span>
+                  <span class="stat-val">{{
+                    formatValue(traderSpecificMetrics.Trades, 'number')
+                  }}</span>
+                </div>
+                <div class="stat-row">
+                  <span class="stat-name">Inventory Imbalance</span>
+                  <span class="stat-val">{{
+                    formatValue(traderSpecificMetrics.Remaining_Trades, 'number')
+                  }}</span>
+                </div>
+                <div class="stat-row">
+                  <span class="stat-name">PnL</span>
+                  <span class="stat-val">{{
+                    formatValue(traderSpecificMetrics.PnL, 'number')
+                  }}</span>
+                </div>
+                <div class="stat-row">
+                  <span class="stat-name">Market Reward</span>
+                  <span class="stat-val">{{
+                    formatValue(traderSpecificMetrics.Reward, 'gbp')
+                  }}</span>
+                </div>
+              </template>
             </div>
 
             <div class="stat-section">
@@ -245,6 +285,12 @@ const isNavigating = ref(false)
 const perMarketQuestions = ref({
   marketDescription: null,
   imbalanceReason: null,
+})
+
+const marketHistory = computed(() => {
+  const history = traderSpecificMetrics.value?.Market_History || []
+  // market 0 is the practice market — it does not count toward the payment
+  return history.filter((m) => m.market > 0)
 })
 
 const hasInventoryImbalance = computed(() => {
@@ -555,6 +601,38 @@ onMounted(() => {
   align-items: center;
   padding: 6px 0;
   border-bottom: 1px solid var(--color-border-light);
+}
+
+.stat-table-wrap {
+  overflow-x: auto;
+}
+
+.stat-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.stat-table th {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  padding: 6px 8px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.stat-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border-light);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.stat-table th:first-child,
+.stat-table td.stat-name {
+  text-align: left;
 }
 
 .stat-name {


### PR DESCRIPTION
Ref #78 (point 1; points 2–4 landed in #79, #80, #81).

**Before:** the final summary's *Your Statistics* section showed only the just-finished market — a single Trades / Inventory Imbalance / PnL / Reward column, indistinguishable from any mid-session summary.

**After:** on the last market the section becomes a table with one column per market (practice market 0 excluded, matching the payment basis), stats over rows as suggested in the issue. Mid-session summaries are unchanged.

E2E (scripted 6-market session; participant trades 2/2/0/1/2/2 orders):

| | Market 1 | Market 2 | Market 3 | Market 4 | Market 5 |
|---|---|---|---|---|---|
| Your Trades | 2 | 0 | 1 | 2 | 2 |
| Inventory Imbalance | 0 | 0 | 1 | 0 | 0 |
| PnL | 85 | 0 | -118.75 | 85 | 85 |
| Market Reward | £8.50 | £0.00 | £0.00 | £8.50 | £8.50 |

…followed by `Your market reward is £5.10` = mean of the reward row (per #81). Note the zero-trade market 2 and the negative-PnL market 3 are both visible as £0.00 columns — participants can now see exactly how the average was formed.

Implementation:
- `accumulated_market_stats` in `back/api/shared.py` (same lifecycle as `accumulated_rewards`; cleared in both admin reset endpoints)
- snapshot written alongside the reward in `trader_info`; returned as `Market_History` (chronological, market 0 = practice)
- `MarketSummary.vue` renders the table only when `isLastMarket` and history is present, so it degrades gracefully (e.g. backend restart mid-session → falls back to the old single-market view)

Known limitation (pre-existing): the history lives in backend memory, so a backend restart mid-session loses earlier markets' rows (payment pool included — that was already true of `accumulated_rewards`). Worth a follow-up if it matters for lab days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
